### PR TITLE
Fix: Markdown link syntax error

### DIFF
--- a/src/pages/report/2021-report.mdx
+++ b/src/pages/report/2021-report.mdx
@@ -28,7 +28,7 @@ We worked on smaller self contained projects such as [the memebox](https://githu
 ## Talks
 - Tek Fog: Dangerous New World. The Wire. [[LINK](https://twitter.com/onosmosis/status/1482980287458193412)]
 - Beyond Commerce: Working on Tech that Benefits Society. Through the Corporate Glass Podcast. [[LINK](https://www.throughthecorporateglass.com/tech-benefit-society)]
-- Crawling the Web for Poetry with (Draft)[https://dra-ft.site/]. [[LINK](https://youtu.be/EBRC6dt62Ts)].
+- Crawling the Web for Poetry with [Draft](https://dra-ft.site/). [[LINK](https://youtu.be/EBRC6dt62Ts)].
 - Between Fake and The News: The Long Game Against Information Disorder. IIT Jodhpur, Digital Humanities Series.
 
 ## Community Use Cases:


### PR DESCRIPTION
How it looks currently on the live website (before we merge this PR):

![image](https://user-images.githubusercontent.com/527598/171004834-b4071173-1705-4c76-894d-4c40f85226a0.png)
