### PR TITLE
Feat: Added SEO tags and dynamic Social Cards for Blogs

### DIFF
--- a/src/components/atomic/seo.js
+++ b/src/components/atomic/seo.js
@@ -72,14 +72,22 @@ function SEO({ description, lang, meta, title, heading }) {
       <meta property="description" content={metaDescription} />
       <meta property="og:title" content={heading} />
       <meta property="og:description" content={metaDescription} />
-      <meta property="og:image" content={`${baseURL}${socialImageURL}`} />
+      <meta property="og:image" content={`${baseURL}${meta.cover? `/${meta.cover}`: socialImageURL}`} />
       <meta property="og:type" content={"website"} />
       <meta name="twitter:card" content={"summary_large_image"} />
       <meta name="twitter:site" content={"@tattlemade"} />
       <meta name="twitter:creator" content={"@tattlemade"} />
       <meta name="twitter:title" content={heading} />
       <meta name="twitter:description" content={metaDescription} />
-      <meta name="twitter:image" content={`${baseURL}${socialImageURL}`} />
+      <meta name="twitter:image" content={`${baseURL}${meta.cover? `/${meta.cover}`: socialImageURL}`} />
+      {meta.tags && (
+        <meta
+          name="keywords"
+          content={meta.tags
+            .join(",")
+            .concat(meta.project ? `,${meta.project}` : "")}
+        />
+      )}
       <script
         async
         defer

--- a/src/components/default-blog-layout.js
+++ b/src/components/default-blog-layout.js
@@ -22,7 +22,7 @@ const shortcodes = {
 }
 
 export default function PageTemplate({ data: { mdx, allMdx } }) {
-  const { name, author, project, date, excerpt } = mdx.frontmatter
+  const { name, author, project, date, excerpt, cover } = mdx.frontmatter
   const tags = mdx.frontmatter.tags
     ? mdx.frontmatter.tags.split(",").map(tag => tag.trim())
     : []
@@ -54,7 +54,7 @@ export default function PageTemplate({ data: { mdx, allMdx } }) {
       primaryNav={primaryNav}
       expandCenter={true}
       isMDXPage={true}
-      meta={{ name: name, excerpt: excerpt, project: project, tags: tags }}
+      meta={{ name: name, excerpt: excerpt, project: project, tags: tags, cover:cover }}
     >
       <MDXProvider components={shortcodes}>
         <Box>
@@ -98,6 +98,7 @@ export const pageQuery = graphql`
         project
         date
         tags
+        cover
       }
     }
     allMdx {


### PR DESCRIPTION
This PR resolves issues #108 and #26.

For Blog Posts, all the tags for that post (plus the name of the project if exists in frontmatter) are included in the 
`meta name= keywords` tag. (Related to Issue #108)

For Blog Posts, if the post contains a cover, then the `og:image` and `twitter:image` meta tags include that cover's URL, else they would include the general social cards URL (same as before). (Related to Issue #26)

I have verified that the meta tags are correctly included by inspecting the page source after building the project.