### PR TITLE
Feat: Created-Sitemap-for-Website

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -50,6 +50,15 @@ module.exports = {
         name: `community`,
         path: `${__dirname}/src/community`,
       },
+      
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `pages`,
+        path: `${__dirname}/src/pages`,
+      },
+      
     },
 
     `gatsby-transformer-sharp`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,8 +44,8 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   const tags_set = new Set()
   result.data.allMdx.nodes.forEach(node => {
     const tags_arr = node.frontmatter.tags
-    ? node.frontmatter.tags.split(",").map(tag => tag.trim())
-    : []
+      ? node.frontmatter.tags.split(",").map(tag => tag.trim())
+      : []
     if (tags_arr) {
       tags_arr.forEach(tag => tags_set.add(tag))
     }
@@ -57,6 +57,38 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   // } catch {
   //   await fs.mkdir("./src/people/avatar")
   // }
+
+
+  // The array should be similar to the tree (in default-sitemap-layout). If node exists pass node, else make a node object to pass name in it.
+  const siteMapNodes = [] 
+
+  createPage({
+    path: `/blog/`,
+    component: path.resolve(`./src/components/default-blog-index-layout.js`),
+    context: { projects },
+  })
+  //siteMapURLs.set("Blogs", "/blog")
+    siteMapNodes.push({name:"blog",isDir:false,node:{name:"blog"}})
+
+  // CREATE TAGS PAGE
+  tags_set.forEach(tag => {
+    createPage({
+      path: `/blog/tags/${tag}`,
+      component: path.resolve("./src/components/default-tag-page-layout.js"),
+      context: { tag },
+    })
+  })
+
+  // Create Tags Project Page
+  projects.forEach(project => {
+    createPage({
+      path: `/blog/tags/project/${project}`,
+      component: path.resolve(
+        "./src/components/default-tag-project-page-layout.js"
+      ),
+      context: { project },
+    })
+  })
 
   nodes.forEach(async node => {
     const { fileAbsolutePath, id } = node
@@ -95,22 +127,8 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       })
     }
 
-    createPage({
-      path: `/blog/`,
-      component: path.resolve(`./src/components/default-blog-index-layout.js`),
-      context: { projects },
-    })
-
-    // CREATE TAGS PAGE
-    tags_set.forEach(tag => {
-      createPage({
-        path: `/blog/tags/${tag}`,
-        component: path.resolve("./src/components/default-tag-page-layout.js"),
-        context: { tag },
-      })
-    })
-
-    // CREATE PROJECTS
+    //TODO:Reconsider this 
+    // CREATE PROJECTS 
     if (fileAbsolutePath.indexOf("/src/project/") !== -1) {
       createPage({
         path: `/project/${node.slug}`,
@@ -119,16 +137,12 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       })
     }
 
-    // Create Tags Project Page
-    projects.forEach(project => {
-      createPage({
-        path: `/blog/tags/project/${project}`,
-        component: path.resolve(
-          "./src/components/default-tag-project-page-layout.js"
-        ),
-        context: { id, project },
-      })
-    })
+  })
+  // Create the Sitemap Page
+  await createPage({
+    path: `/sitemap/`,
+    component: path.resolve(`./src/components/default-sitemap-layout.js`),
+    context: { siteMapNodes:siteMapNodes },
   })
 }
 

--- a/src/components/default-sitemap-layout.js
+++ b/src/components/default-sitemap-layout.js
@@ -1,0 +1,144 @@
+import { graphql } from "gatsby"
+import React from "react"
+import DefaultLayout from "./default-layout"
+import { Box, Heading, Text } from "grommet"
+import { PlainLink } from "./atomic/TattleLinks"
+import DefaultLayoutNarrow from "./default-layout-narrow"
+import { generateDisplayName } from "../lib/generate-display-name"
+
+export default function SiteMapPage({ pageContext, data }) {
+  //PagContext may have siteMapNodes of type Tree Structure commented below.
+  const nodes = data.allFile.nodes
+  const ignoreDirs = ["v2"]
+  const ignoreFiles = ["404", "theme", "_index", "index", "video"]
+  /**
+   * Tree Structure
+   * [
+   *  { name: products, children:[{name:viral-spiral, children:[index.jsx, presskit]}, {name: feluda}, {name: index.jsx}, {name: khoj.jsx}]}
+   * ]
+   */
+
+  const pageContextNodes = pageContext.siteMapNodes || []
+  const tree = pageContextNodes.concat(buildTree(nodes))
+
+  function buildTree(nodes) {
+    const tree = []
+    let current = tree
+
+    nodes.forEach(node => {
+      if (node.relativeDirectory) {
+        const directoryParts = node.relativeDirectory.split("/")
+        current = tree
+
+        directoryParts.forEach(part => {
+          let existingNode = current.find(item => item.name === part)
+
+          if (!existingNode) {
+            existingNode = { name: part, isDir: true, node: null, children: [] }
+            current.push(existingNode)
+          }
+
+          current = existingNode.children
+        })
+      }
+      current.push({ name: node.name, isDir: false, node: node })
+    })
+
+    return tree
+  }
+  let a = []
+  const renderTree = treeNodes => {
+    return treeNodes.map(tn => {
+      if (ignoreDirs.indexOf(tn.name) !== -1) {
+        return null
+      }
+      const displayName = (
+        <Text size="small">
+          {generateDisplayName(
+            tn.node?.childrenMdx?.find(child => child.frontmatter)?.frontmatter
+              ?.name ?? tn.name
+          )}
+        </Text>
+      )
+
+      if (tn.isDir) {
+        const indexNode = tn.children.find(n => n.name === "index")
+        if (indexNode) {
+          return (
+            <li>
+              <div style={{ marginLeft: 2 }}>
+                <PlainLink to={`/${indexNode.node.relativeDirectory}`}>
+                  {displayName}
+                </PlainLink>
+                {tn.children && <ul>{renderTree(tn.children)}</ul>}
+              </div>
+            </li>
+          )
+        } else {
+          return (
+            <li>
+              <div style={{ marginLeft: 2 }}>
+                {displayName}
+                {tn.children && <ul>{renderTree(tn.children)}</ul>}
+              </div>
+            </li>
+          )
+        }
+      } else {
+        return (
+          tn.name !== "index" &&
+          ignoreFiles.indexOf(tn.name) === -1 && (
+            <li>
+              <div style={{ marginLeft: 2 }}>
+                <PlainLink
+                  to={`${
+                    tn.node.relativeDirectory
+                      ? `/${tn.node.relativeDirectory}/${tn.node.name}`
+                      : `/${tn.node.name}`
+                  }`}
+                >
+                  {displayName}
+                </PlainLink>
+              </div>
+            </li>
+          )
+        )
+      }
+    })
+  }
+
+  return (
+    <>
+      <DefaultLayoutNarrow>
+        <Box width="100%">
+          <Heading margin={{ horizontal: "auto" }}>Site Map</Heading>
+
+          <Box>
+            <ul>{renderTree(tree)}</ul>;
+          </Box>
+        </Box>
+      </DefaultLayoutNarrow>
+    </>
+  )
+}
+
+export const query = graphql`
+  query {
+    allFile(filter: { absolutePath: { regex: "/pages/" } }) {
+      nodes {
+        id
+        name
+        absolutePath
+        relativeDirectory
+        relativePath
+        childrenMdx {
+          excerpt
+          frontmatter {
+            title
+            name
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -24,6 +24,12 @@ export const footerItems = {
       target: "/contact",
       type: "internal",
     },
+    {
+      id: 4,
+      label: "Site Map",
+      target: "/sitemap",
+      type: "internal",
+    },
   ],
 }
 

--- a/src/lib/generate-display-name.js
+++ b/src/lib/generate-display-name.js
@@ -1,0 +1,24 @@
+/**
+ * 
+ * The function replaces underscores and hyphens with spaces,
+ * capitalizes the first letter of each word, and returns the formatted string.
+ * If the input is not a string, it returns an empty string.
+ * 
+ * @param {string} fileName 
+ * @returns {string}
+ */
+export function generateDisplayName(fileName) {
+
+    if (typeof fileName !== 'string') {
+        console.warn('Expected a string as input, but received:', fileName);
+        return '';
+    }
+    // Split the string by underscores and hyphens
+    const words = fileName.split(/[_-]/);
+
+    const displayName = words.map(word => 
+        word.charAt(0).toUpperCase() + word.slice(1)
+    ).join(' ');
+
+    return displayName;
+}


### PR DESCRIPTION
This PR resolves issue #109 

In this PR I created the Sitemap for the website, which can be accessed at the `/sitemap` URL and from the website's footer. 

### Changes in the gatsby-node file
In the `gatsby-node` file, a new sitemap page has been created with the help of the `default-sitemap-layout` component. Also, a `siteMapNodes` has been created which is an array of page-nodes, to be used in the sitemap. This is then passed as a context to the `default-sitemap-layout` component. 

### The `default-sitemap-layout` component
This component renders the sitemap. It makes a GraphQl query to fetch the data of all the files in the pages directory. It is then combined with the siteMapNodes which was passed as pageContext from the gatsby-node file. Then it renders all the relevant files. 


### Minor Fixes
In the gatsby-node.js file, I have shifted the createPage functions for some pages out of the nodes loop so they don't get created repeatedly in the nodes loop. 