### PR TITLE
Feat: Implemented project based categorization of updates

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -90,6 +90,17 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     })
   })
 
+  // Create Tags Project Page for Updates
+  projects.forEach(project => {
+    createPage({
+      path: `/updates/tags/project/${project}`,
+      component: path.resolve(
+        "./src/components/default-updates-project-tag-page-layout.js"
+      ),
+      context: { project },
+    })
+  })
+
   nodes.forEach(async node => {
     const { fileAbsolutePath, id } = node
     // console.log(`------ : ${id}`)

--- a/src/components/UpdatesTagPage.jsx
+++ b/src/components/UpdatesTagPage.jsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { Box, Heading } from "grommet"
+import { PlainLink } from "./atomic/TattleLinks"
+import DefaultLayout from "./default-layout"
+import NarrowContentWrapper from "./atomic/layout/narrow-content-wrapper"
+import NarrowSection from "./atomic/layout/narrow-section"
+import TagBubbleBlog from "./atomic/TagBubbleBlog"
+import { UpdatesIndex } from "../pages/updates"
+
+/**
+ * Tag Page component, to be used to render the Tag Page (To show updates with a given Tag).
+ * @param {Object} props
+ * @param {string} props.pageHeading -The Heading of the Page
+ * @param {string} props.tag -The Tag of which the Page is
+ * @param {Object} props.tagCounts -An object mapping each tag to its updates count.
+ * @param {Object[]} props.updates -Array of Blog Nodes
+ *
+ */
+
+function UpdatesTagPage({ pageHeading, tag, tagCounts, updates }) {
+  return (
+    <DefaultLayout>
+      <NarrowContentWrapper>
+        <NarrowSection>
+          <Box>
+          <Box basis={"xsmall"} gap="">
+        <Box>
+          <PlainLink to={"/updates"}>
+            <Heading level={4}>back to all Updates</Heading>
+          </PlainLink>
+        </Box>
+        <Box direction="row-responsive" gap="small" align="center">
+          <Heading level={3}>{pageHeading}</Heading>
+          <TagBubbleBlog data={{ label: tag, count: tagCounts[tag] }} />
+        </Box>
+      </Box>
+            <UpdatesIndex updates={updates} />
+          </Box>
+        </NarrowSection>
+      </NarrowContentWrapper>
+    </DefaultLayout>
+
+  )
+}
+export default UpdatesTagPage

--- a/src/components/default-blog-index-layout.js
+++ b/src/components/default-blog-index-layout.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby"
 import DefaultLayout from "./default-layout"
 import { Box } from "grommet"
 import { AllBlogsIndexLayout } from "./atomic/layout/all-blogs-index-layout"
-import useTags from "../hooks/useTags"
+import useBlogTags from "../hooks/useBlogTags"
 import TagsRenderer from "./TagsRenderer"
 
 export const byline = (name, project) => {
@@ -20,7 +20,7 @@ const BlogIndex = ({ data, pageContext }) => {
     projectTagsCounts,
     sortedUniqueTags,
     sortedProjectTags,
-  } = useTags()
+  } = useBlogTags()
 
   return (
     <DefaultLayout>

--- a/src/components/default-blog-layout.js
+++ b/src/components/default-blog-layout.js
@@ -12,7 +12,7 @@ import { Heading } from "grommet"
 import { useLocation } from "@reach/router"
 import CustomCodeBlock from "./atomic/customCodeBlock"
 import InlineCodeBlock from "./atomic/inlineCodeBlock"
-import useTags from "../hooks/useTags"
+import useBlogTags from "../hooks/useBlogTags"
 
 import { projectSlugMaker } from "../lib/project-slug-maker"
 import TagsRenderer from "./TagsRenderer"
@@ -26,7 +26,7 @@ const shortcodes = {
 
 export default function PageTemplate({ data: { mdx, allMdx } }) {
 
-  const { tagCounts, projectTagsCounts } = useTags()
+  const { tagCounts, projectTagsCounts } = useBlogTags()
   const { name, author, project, date, excerpt, cover } = mdx.frontmatter
   const tags = mdx.frontmatter.tags
     ? mdx.frontmatter.tags.split(",").map(tag => tag.trim())

--- a/src/components/default-tag-page-layout.js
+++ b/src/components/default-tag-page-layout.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
-import useTags from "../hooks/useTags"
+import useBlogTags from "../hooks/useBlogTags"
 import TagPage from "./TagPage"
 
 const byline = (author, project) => {
@@ -9,7 +9,7 @@ const byline = (author, project) => {
 }
 
 export default function TagTemplate({ data, pageContext }) {
-  const { tagCounts } = useTags()
+  const { tagCounts } = useBlogTags()
   const { allMdx } = data
   const tag = pageContext.tag
 
@@ -40,7 +40,7 @@ export const pageQuery = graphql`
           project
           date
           tags
-		  cover
+		      cover
         }
       }
     }

--- a/src/components/default-tag-project-page-layout.js
+++ b/src/components/default-tag-project-page-layout.js
@@ -1,11 +1,11 @@
 import { graphql } from "gatsby"
 import React from "react"
 import { projectSlugMaker } from "../lib/project-slug-maker"
-import useTags from "../hooks/useTags"
+import useBlogTags from "../hooks/useBlogTags"
 import TagPage from "./TagPage"
 
 export default function TagProjectPage({ data,pageContext }) {
-  const {projectTagsCounts} = useTags();
+  const {projectTagsCounts} = useBlogTags();
   const blogNodes = data.allMdx.nodes;
   const project = pageContext.project;
   const projectBlogs =  blogNodes.filter(blog=>projectSlugMaker(blog.frontmatter.project)===project);

--- a/src/components/default-updates-project-tag-page-layout.js
+++ b/src/components/default-updates-project-tag-page-layout.js
@@ -1,0 +1,40 @@
+import { graphql } from "gatsby"
+import React from "react"
+import { projectSlugMaker } from "../lib/project-slug-maker"
+import useUpdateTags from "../hooks/useUpdateTags"
+import UpdatesTagPage from "./UpdatesTagPage"
+
+export default function UpdatesTagProjectPage({ data,pageContext }) {
+  const {projectTagsCounts} = useUpdateTags();
+  const updateNodes = data.allMdx.nodes;
+  const project = pageContext.project;
+  const projectupdates =  updateNodes.filter(update=>projectSlugMaker(update.frontmatter.project)===project);
+
+  return (
+    <UpdatesTagPage updates={projectupdates} pageHeading={"Updates with Project Tag:"} tag={project} tagCounts={projectTagsCounts} />
+  )
+}
+
+export const query = graphql`
+  query {
+    allMdx(
+      filter: {
+        fileAbsolutePath: { regex: "/src/updates/" }
+      }
+    ) {
+      nodes {
+        frontmatter {
+          url
+          excerpt
+          date
+          tags
+          title
+          project
+        }
+        id
+        slug
+        fileAbsolutePath
+      }
+    }
+  }
+`

--- a/src/hooks/useBlogTags.jsx
+++ b/src/hooks/useBlogTags.jsx
@@ -15,7 +15,7 @@ import { projectSlugMaker } from "../lib/project-slug-maker"
  * @returns {TagsData}
  * 
  */
-export default function useTags() {
+export default function useBlogTags() {
   const data = useStaticQuery(graphql`
     query {
       allMdx(filter: { fileAbsolutePath: { regex: "/.*/src/blog/" } }) {

--- a/src/hooks/useUpdateTags.jsx
+++ b/src/hooks/useUpdateTags.jsx
@@ -1,0 +1,79 @@
+import { graphql, useStaticQuery } from "gatsby"
+import { projectSlugMaker } from "../lib/project-slug-maker"
+
+/**
+ * A custom Hook to provide all the data related to all tags (general and project tags) used in the updates. 
+ *
+ * @typedef {Object} TagsData
+ * @property {Object} tagCounts - An object mapping each tag to its count.
+ * @property {Object} projectTagsCounts - An object mapping each project slug (or tag) to its count.
+ * @property {string[]} projectsTags - Array of all unique project slugs.
+ * @property {string[]} uniqueTags - Array of all the unique tags.
+ * @property {string[]} sortedUniqueTags - An array of unique tags sorted by their count in descending order. Entries same as uniqueTags, but sorted
+ * @property {string[]} sortedProjectTags - An array of project slugs sorted by their count in descending order. Entries same as projectsTags, but sorted
+ * 
+ * @returns {TagsData}
+ * 
+ */
+export default function useUpdateTags() {
+  const data = useStaticQuery(graphql`
+    query {
+      allMdx(filter: { fileAbsolutePath: { regex: "/.*/src/updates/" } }) {
+        nodes {
+          frontmatter {
+            tags
+            project
+          }
+        }
+      }
+    }
+  `)
+
+  const updates = data.allMdx.nodes
+  const tagCounts = {}
+  const projectTagsCounts = {}
+  const uniqueTagsSet = new Set()
+  const projectsTags = [
+    ...new Set(
+      updates
+        .map(node => node.frontmatter.project)
+        .filter(project => typeof project === "string" && project.trim() !== "")
+        .map(project => projectSlugMaker(project))
+    ),
+  ]
+
+  updates.forEach(blog => {
+    if (blog.frontmatter.tags) {
+      const blogTags = blog.frontmatter.tags.split(",").map(tag => tag.trim())
+      // tags.push(...blogTags);
+      blogTags.forEach(tag => uniqueTagsSet.add(tag))
+      blogTags.forEach(tag => {
+        tagCounts[tag] = (tagCounts[tag] || 0) + 1
+      })
+    }
+    //For Project Tags
+    const project = blog.frontmatter.project
+    if (project && typeof project === "string" && project.trim() !== "") {
+      let projectSlug = projectSlugMaker(blog.frontmatter.project)
+      projectTagsCounts[projectSlug] = (projectTagsCounts[projectSlug] || 0) + 1
+    }
+  })
+
+  const uniqueTags = Array.from(uniqueTagsSet)
+  const sortedUniqueTags = uniqueTags.sort(
+    (a, b) => tagCounts[b] - tagCounts[a]
+  )
+
+  const sortedProjectTags = projectsTags.sort(
+    (a, b) => projectTagsCounts[b] - projectTagsCounts[a]
+  )
+
+  return {
+    tagCounts,
+    projectTagsCounts,
+    projectsTags,
+    uniqueTags,
+    sortedUniqueTags,
+    sortedProjectTags,
+  }
+}

--- a/src/pages/updates.js
+++ b/src/pages/updates.js
@@ -7,6 +7,9 @@ import NarrowContentWrapper from "../components/atomic/layout/narrow-content-wra
 import TagBubble from "../components/atomic/TagBubble"
 import { PlainExternalLink } from "../components/atomic/TattleLinks"
 import { graphql } from "gatsby"
+import { projectSlugMaker } from "../lib/project-slug-maker"
+import TagsRenderer from "../components/TagsRenderer"
+import useUpdateTags from "../hooks/useUpdateTags"
 
 const UpdateListItem = ({ node }) => {
   const formatDate = dateString => {
@@ -22,6 +25,11 @@ const UpdateListItem = ({ node }) => {
   const tags = node.frontmatter.tags
     ? node.frontmatter.tags.split(",").map(tag => tag.trim())
     : []
+
+    if(node.frontmatter.project){
+      tags.push(projectSlugMaker(node.frontmatter.project));
+    }
+    
   return (
     <Box direction={"column"} margin={{ top: "xsmall", bottom: "small" }}>
       <Box height={"7.324px"} />
@@ -62,7 +70,11 @@ const UpdateListItem = ({ node }) => {
   )
 }
 
-const updates = ({ data }) => {
+const Updates = ({ data }) => {
+  const {
+    projectTagsCounts,
+    sortedProjectTags,
+  } = useUpdateTags()
   const updates = data.allMdx.nodes
 
   return (
@@ -70,11 +82,13 @@ const updates = ({ data }) => {
       <NarrowContentWrapper>
         <NarrowSection>
           <Box>
-            <NarrowSection>
-              {updates.map(node => (
-                <UpdateListItem node={node} key={node.id} />
-              ))}
-            </NarrowSection>
+            <TagsRenderer
+              sortedUniqueTags={sortedProjectTags}
+              tagBaseURL="/updates/tags/project/"
+              tagCounts={projectTagsCounts}
+              tagTypeHeading="Projects: "
+            />
+            <UpdatesIndex updates={updates} />
           </Box>
         </NarrowSection>
       </NarrowContentWrapper>
@@ -82,7 +96,17 @@ const updates = ({ data }) => {
   )
 }
 
-export default updates
+export default Updates
+
+export function UpdatesIndex({ updates }) {
+  return (
+    <NarrowSection>
+      {updates.map(node => (
+        <UpdateListItem node={node} key={node.id} />
+      ))}
+    </NarrowSection>
+  )
+}
 
 //export page query
 export const query = graphql`
@@ -98,6 +122,7 @@ export const query = graphql`
           date
           tags
           title
+          project
         }
         id
         slug

--- a/src/updates/2022-02-15_Viral-Spiral-gets-Grant-from-PCE-at-the-Mercatus-Center.mdx
+++ b/src/updates/2022-02-15_Viral-Spiral-gets-Grant-from-PCE-at-the-Mercatus-Center.mdx
@@ -4,4 +4,5 @@ title: "Viral Spiral gets Grant from PCE at the Mercatus Center"
 excerpt: "Grant from Pluralism and Civic Exchange Program at the Mercatus Center"
 url: "https://twitter.com/mercatus/status/1493599381941112843"
 tags: Media Mentions
+project: viral-spiral
 ---

--- a/src/updates/uli-github-open-source-friday.mdx
+++ b/src/updates/uli-github-open-source-friday.mdx
@@ -4,4 +4,5 @@ title: "Uli was featured on Github Open Source Friday"
 excerpt: 'Denny and Kaustubha were interviewed by Andrea from Github for their weekly show "Open Source Friday". We got to share how Uli came about, our plans for it in the future, and our take on interdisciplinary work in tech.'
 url: "https://www.youtube.com/watch?v=g2rlQUdHJYA"
 tags: Media Mention
+project: uli
 ---


### PR DESCRIPTION
This PR solves issue #172 

Added project-based categorization of updates. 

Followed a similar approach to get updated tags and make tag pages as did for the blogs (pull request https://github.com/tattle-made/website/pull/164 ).

- Created project tag pages in `gatsby-node` file for every tag
- Created a `default-updates-project-tag-page` for the project tag page of updates. (used in `gatsby-node`).
- Inside `updates.jsx`, made a separate component UpdatesIndex to render all the updates. This is being also used in the UpdatesTagPage. 
- Created useUpdateTags to fetch all the tags related to updates.
- If an update (mdx file) has a project field then its tag would be added to that update's tags as well.
- Changed the old useTags hook to useBlogTags to identify the hooks better for updates and blogs.

**Please NOTE:** It is implemented in such a way that categorizing based on general tags and their respective pages can be implemented later if required. 