### PR TITLE
Fix: Wrapped root element with Grommet to access its features

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,6 @@
-require("./prism-cb.css")
+import "./prism-cb.css"
+import React from "react"
+import { Grommet } from "grommet"
 /**
  * Implement Gatsby's Browser APIs in this file.
  *
@@ -6,3 +8,8 @@ require("./prism-cb.css")
  */
 
 // You can delete this file if you're not using it
+
+// Gatsby API to set Wrapper components. Wrapping entire root with Grommet to get access to especially ResponsiveContext
+export const wrapRootElement = ({ element }) => {
+  return <Grommet>{element}</Grommet>
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,6 @@
+import "./prism-cb.css"
+import React from "react"
+import { Grommet } from "grommet"
 /**
  * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
  *
@@ -5,3 +8,8 @@
  */
 
 // You can delete this file if you're not using it
+
+// Gatsby API to set Wrapper components. Wrapping entire root with Grommet to get access to especially ResponsiveContext
+export const wrapRootElement = ({ element }) => {
+  return <Grommet>{element}</Grommet>
+}


### PR DESCRIPTION
In this PR, I have wrapped the root element with the `Grommet` component to access its features, especially ResponsiveContext. Now we can implement ResponsiveContext anywhere in the project with the help of the `useContext` hook. Earlier we would need to wrap every component which required to use `ResponsiveContext` with `ResponsiveContext.Consumer`.