### PR TITLE
Feat: added blogs and updates to product page

### DIFF
--- a/src/components/LatestBlogsUpdates.jsx
+++ b/src/components/LatestBlogsUpdates.jsx
@@ -1,9 +1,8 @@
 import { graphql, useStaticQuery } from "gatsby"
-import React, { useContext } from "react"
+import React from "react"
 import NarrowContentWrapper from "./atomic/layout/narrow-content-wrapper"
-import { Anchor, Box, Heading, ResponsiveContext, Text } from "grommet"
-import { PlainLink } from "./atomic/TattleLinks"
-import { ExternalLink } from "react-feather"
+import {Box, Heading} from "grommet"
+import { LatestEntries } from "./LatestEntries"
 
 export default function LatestBlogsUpdates() {
   const data = useStaticQuery(
@@ -87,88 +86,4 @@ export default function LatestBlogsUpdates() {
       </Box>
     </>
   )
-}
-
-function formatDateLatestEntries(date) {
-  let dateString = new Date(date).toDateString("ind")
-  return dateString
-    .split(" ")
-    .slice(1)
-    .join(" ")
-}
-
-function LatestEntries({ entries, isUpdate }) {
-  const size = useContext(ResponsiveContext)
-
-  return entries.map(entry => {
-    return (
-      <Box
-        width={"full"}
-        flex
-        direction="row-responsive"
-        justify="between"
-        margin={{ bottom: "1em" }}
-      >
-        <Box width={size === "small" ? "" : size === "medium" ? "30%" : "15%"}>
-          <Text size={size === "small" ? "xsmall" : "small"}>
-            {formatDateLatestEntries(entry.frontmatter.date)}
-          </Text>
-        </Box>
-
-        <Box
-          width={"full"}
-          alignContent="start"
-          justify="start"
-          pad={{ horizontal: size !== "small" ? "1em" : 0 }}
-        >
-          {isUpdate ? (
-            <Text size="small" weight={600} truncate>
-              {entry.frontmatter.title}
-            </Text>
-          ) : (
-            <Text size="small" weight={600} truncate>
-              <PlainLink to={`/blog/${entry.slug}`}>
-                {entry.frontmatter.name}
-              </PlainLink>
-            </Text>
-          )}
-        </Box>
-
-        {isUpdate ? (
-          <Box
-            width={size === "small" ? "" : size === "medium" ? "25%" : "15%"}
-            align={size === "small" ? "start" : "end"}
-          >
-            {entry.frontmatter.url && entry.frontmatter.url.length !== 0 ? (
-              <PlainLink href={entry.frontmatter.url} target={"_blank"}>
-                <Box
-                  style={{ position: "relative" }}
-                  gap={"xsmall"}
-                  direction={"row"}
-                  align={"center"}
-                  flex
-                >
-                  <Text size={"small"}> Read More</Text>
-                  <ExternalLink
-                    size={10}
-                    style={{ position: "absolute", top: 0, right: -5 }}
-                  />
-                </Box>
-              </PlainLink>
-            ) : null}
-          </Box>
-        ) : (
-          <Box
-            style={{
-              minWidth:
-                size === "small" ? "" : size === "medium" ? "20%" : "15%",
-            }}
-            align={size === "small" ? "start" : "end"}
-          >
-            <Text size="small">{entry.frontmatter?.author}</Text>
-          </Box>
-        )}
-      </Box>
-    )
-  })
 }

--- a/src/components/LatestEntries.jsx
+++ b/src/components/LatestEntries.jsx
@@ -1,0 +1,89 @@
+import React, { useContext } from "react"
+import { Box, ResponsiveContext, Text } from "grommet"
+import { PlainLink } from "./atomic/TattleLinks"
+import { ExternalLink } from "react-feather"
+
+function formatDateLatestEntries(date) {
+  let dateString = new Date(date).toDateString("ind")
+  return dateString
+    .split(" ")
+    .slice(1)
+    .join(" ")
+}
+
+// Component to Display latest entries of Blogs and Updates
+export function LatestEntries({ entries, isUpdate }) {
+  const size = useContext(ResponsiveContext)
+
+  return entries.map(entry => {
+    return (
+      <Box
+        width={"full"}
+        flex
+        direction="row-responsive"
+        justify="between"
+        margin={{ bottom: "1em" }}
+      >
+        <Box width={size === "small" ? "" : size === "medium" ? "30%" : "15%"}>
+          <Text size={size === "small" ? "xsmall" : "small"}>
+            {formatDateLatestEntries(entry.frontmatter.date)}
+          </Text>
+        </Box>
+
+        <Box
+          width={"full"}
+          alignContent="start"
+          justify="start"
+          pad={{ horizontal: size !== "small" ? "1em" : 0 }}
+        >
+          {isUpdate ? (
+            <Text size="small" weight={600} truncate>
+              {entry.frontmatter.title}
+            </Text>
+          ) : (
+            <Text size="small" weight={600} truncate>
+              <PlainLink to={`/blog/${entry.slug}`}>
+                {entry.frontmatter.name}
+              </PlainLink>
+            </Text>
+          )}
+        </Box>
+
+        {isUpdate ? (
+          <Box
+            width={size === "small" ? "" : size === "medium" ? "25%" : "15%"}
+            align={size === "small" ? "start" : "end"}
+          >
+            {entry.frontmatter.url && entry.frontmatter.url.length !== 0 ? (
+              <PlainLink href={entry.frontmatter.url} target={"_blank"}>
+                <Box
+                  style={{ position: "relative" }}
+                  gap={"xsmall"}
+                  direction={"row"}
+                  align={"center"}
+                  flex
+                >
+                  <Text size={"small"}> Read More</Text>
+                  <ExternalLink
+                    size={10}
+                    style={{ position: "absolute", top: 0, right: -5 }}
+                  />
+                </Box>
+              </PlainLink>
+            ) : null}
+          </Box>
+        ) : (
+          <Box
+            style={{
+              minWidth:
+                size === "small" ? "" : size === "medium" ? "20%" : "15%",
+            }}
+            align={size === "small" ? "start" : "end"}
+          >
+            <Text size="small">{entry.frontmatter?.author}</Text>
+          </Box>
+        )}
+      </Box>
+    )
+  })
+}

--- a/src/components/LatestProductBlogsUpdates.jsx
+++ b/src/components/LatestProductBlogsUpdates.jsx
@@ -1,0 +1,96 @@
+import { graphql, useStaticQuery } from "gatsby"
+import React from "react"
+import { projectSlugMaker } from "../lib/project-slug-maker"
+import { generateDisplayName } from "../lib/generate-display-name"
+import { Box, Heading } from "grommet"
+import NarrowContentWrapper from "./atomic/layout/narrow-content-wrapper"
+import { LatestEntries } from "./LatestEntries"
+
+export function LatestProductBlogsUpdates({ projects }) {
+    //projects is an array of string
+  const data = useStaticQuery(
+    graphql`
+      query {
+        latestBlogs: allMdx(
+          sort: { fields: frontmatter___date, order: DESC }
+          filter: { fileAbsolutePath: { regex: "/.*/src/blog/" } }
+        ) {
+          nodes {
+            slug
+            frontmatter {
+              name
+              excerpt
+              author
+              project
+              date
+              tags
+              cover
+            }
+            fileAbsolutePath
+          }
+        }
+
+        latestUpdates: allMdx(
+          sort: { fields: frontmatter___date, order: DESC }
+          filter: { fileAbsolutePath: { regex: "/updates/" } }
+        ) {
+          nodes {
+            frontmatter {
+              url
+              excerpt
+              date
+              tags
+              title
+              project
+            }
+            id
+            slug
+            fileAbsolutePath
+          }
+        }
+      }
+    `
+  )
+
+  if (!projects) return null
+
+  projects = projects.map(p=>projectSlugMaker(p));
+
+  let latestProjectBlogs = data.latestBlogs.nodes.filter(
+    node =>
+      projects.includes(projectSlugMaker(node.frontmatter.project))
+  )
+  let latestProjectUpdates = data.latestUpdates.nodes.filter(
+    node =>
+        projects.includes(projectSlugMaker(node.frontmatter.project))
+  )
+
+  latestProjectBlogs = latestProjectBlogs.slice(0,10);
+  latestProjectUpdates = latestProjectUpdates.slice(0,10);
+
+  return (
+    <>
+      {latestProjectBlogs && latestProjectBlogs.length !== 0 && (
+        <Box>
+          <Box>
+            <Heading level={3}>
+              Latest Blogs
+            </Heading>
+          </Box>
+          <LatestEntries entries={latestProjectBlogs} />
+        </Box>
+      )}
+
+      {latestProjectUpdates && latestProjectUpdates.length !== 0 && (
+        <Box>
+          <Box>
+            <Heading level={3}>
+              Latest Updates
+            </Heading>
+          </Box>
+          <LatestEntries entries={latestProjectUpdates} isUpdate={true} />
+        </Box>
+      )}
+    </>
+  )
+}

--- a/src/pages/products/closed-messaging-checklist.mdx
+++ b/src/pages/products/closed-messaging-checklist.mdx
@@ -1,4 +1,7 @@
-# Responsible Data Collection and Sharing from Closed Messaging Apps
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
+<h1 style={{lineHeight:"1.5em"}}>Responsible Data Collection and Sharing from Closed Messaging Apps</h1>
+
 ## A Checklist 
 (*Last Updated*: April 29, 2021)
 
@@ -98,3 +101,5 @@ By codifying responsible data management practices prior to the study, researche
 
 
 ---
+{/* Add projects here to show the blogs and updates */}
+<LatestProductBlogsUpdates projects={[]}/>

--- a/src/pages/products/dau.mdx
+++ b/src/pages/products/dau.mdx
@@ -1,5 +1,6 @@
 import { Anchor, Text, Box } from "grommet"
 import { PlainLink } from "../../components/atomic/TattleLinks"
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
 
 # Deepfakes Analysis Unit
 
@@ -28,3 +29,5 @@ The [DAU's](https://dau.mcaindia.in/) (Deepfakes Analysis Unit) mission is to ge
 <a href="https://mcaindia.in/"><Text size={"small"}>Misinformation Combat Alliance</Text></a>
 <Text size={"small"}>Tattle</Text>
 <Text size={"small"}>Meta (Funding Partner)</Text>
+
+<LatestProductBlogsUpdates projects={["dau"]}/>

--- a/src/pages/products/facts.jsx
+++ b/src/pages/products/facts.jsx
@@ -5,6 +5,8 @@ import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-
 import NarrowSection from "../../components/atomic/layout/narrow-section"
 import { PlainLink } from "../../components/atomic/TattleLinks"
 import { graphql, useStaticQuery } from "gatsby"
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
 
 const Page = () => {
   const { cover_image } = useStaticQuery(graphql`
@@ -43,7 +45,7 @@ const Page = () => {
       </NarrowContentWrapper>
 
       <NarrowContentWrapper>
-        <NarrowSection>
+        {/* <NarrowSection>
           <Heading level={2}>Recent Blogs</Heading>
           <Paragraph fill margin={"none"}>
             <PlainLink to="/blog/factshala-project-reading-list">
@@ -61,6 +63,9 @@ const Page = () => {
             </PlainLink>
             <Text size={"small"}> Denny George</Text>
           </Paragraph>
+        </NarrowSection> */}
+        <NarrowSection>
+        <LatestProductBlogsUpdates projects={["facts","factshala","mlcc"]} />
         </NarrowSection>
       </NarrowContentWrapper>
 

--- a/src/pages/products/feluda.jsx
+++ b/src/pages/products/feluda.jsx
@@ -4,6 +4,8 @@ import DefaultLayout from "../../components/default-layout"
 import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-wrapper"
 import { Anchor, Box, Heading, Image, List, Paragraph, Text } from "grommet"
 import { Link } from "gatsby"
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
 
 const DPGLogo = () => (
   <svg
@@ -284,6 +286,11 @@ const Page = () => (
           )}
         </List>
       </NarrowSection>
+      
+      <NarrowSection>
+      <LatestProductBlogsUpdates projects={["feluda"]}/>
+      </NarrowSection>
+
     </NarrowContentWrapper>
   </DefaultLayout>
 )

--- a/src/pages/products/gftw.mdx
+++ b/src/pages/products/gftw.mdx
@@ -1,3 +1,5 @@
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
 ## Introduction to the Study
 
 Any reconceptualization of the Internet requires rethinking of incentives not only for content creation but also for content discovery and 
@@ -50,9 +52,12 @@ We aim to continue to do this kind of research on incentives and content creatio
 * [Preprint](https://psyarxiv.com/nykxz)
 * [Final report for the project](https://community.interledger.org/denntenna/final-report-for-using-web-monetisation-for-incentivising-sharing-of-good-content-1gef)
 
+
 ## Key Team Members
 
 * Hansika Kapoor, Monk Prayogshala
 * Denny George, Tattle
 * Arathy Puthillam, Monk Prayogshala
 * Yash Budhwar, Tattle
+
+<LatestProductBlogsUpdates projects={["Grant for the Web"]}/>

--- a/src/pages/products/github-indices.mdx
+++ b/src/pages/products/github-indices.mdx
@@ -1,4 +1,6 @@
-# Project with GitHub to develop indices for public policy, international development and economic development. 
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
+<h1 style={{lineHeight:"1.5em"}}> Project with GitHub to develop indices for public policy, international development and economic development.</h1> 
 
 This project has concluded. 
 
@@ -20,3 +22,5 @@ Between February 2022 to August 2022 we conduced one-on-one interviews and focus
 ## Outcomes:
 * A report by GitHub is forthcoming. 
 * The work was presented at RightsCon 2023. The session was titled: 'Developing indexes on internet platform data for social sector research.' 
+
+<LatestProductBlogsUpdates projects={["github indices"]} />

--- a/src/pages/products/jod-bot.mdx
+++ b/src/pages/products/jod-bot.mdx
@@ -1,3 +1,5 @@
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
 # Jod Bot
 
 Jod Bot is a Telegram Bot that lets you push content to Tattle's archive and add tags to it. 
@@ -5,3 +7,5 @@ Jod Bot is a Telegram Bot that lets you push content to Tattle's archive and add
 [Go to Service](https://t.me/TattleJodBot) (Telegram Bot Link)
 
 [Got To Code Repository](https://github.com/tattle-made/archive-telegram-bot)
+
+<LatestProductBlogsUpdates projects={["jod bot"]}/>

--- a/src/pages/products/khoj.mdx
+++ b/src/pages/products/khoj.mdx
@@ -1,4 +1,5 @@
 import {Box, Text} from 'grommet'
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
 
 # Khoj
 
@@ -14,7 +15,7 @@ Khoj is a service that makes it easy to verify messages you receive on your soci
 
 ![Khoj App and Community UI](../../images/khoj-app-community-ui.png)
 
-<!-- [Download our app from the Play Store](https://play.google.com/store/apps/details?id=in.co.tattle.khoj) -->
+{/* [Download our app from the Play Store](https://play.google.com/store/apps/details?id=in.co.tattle.khoj) */}
 
 If you wish to answer queries regarding social media posts from users using our Community UI, please reach out to us at admin@tattle.co.in
 
@@ -24,6 +25,8 @@ Tattle Khoj is the front end for Tattle's search API, but plugged only to the da
 
 ![Gif showing Khoj being used](https://tattle-media.s3.amazonaws.com/khoj-demo.gif)
 
-<!-- [Go to Service](https://services.tattle.co.in/khoj/) -->
+{/* <!-- [Go to Service](https://services.tattle.co.in/khoj/) --> */}
 
 [Go to Code Repository](https://github.com/tattle-made/kosh)
+
+<LatestProductBlogsUpdates projects={["khoj"]}/>

--- a/src/pages/products/kosh.jsx
+++ b/src/pages/products/kosh.jsx
@@ -3,6 +3,7 @@ import NarrowSection from "../../components/atomic/layout/narrow-section"
 import DefaultLayout from "../../components/default-layout"
 import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-wrapper"
 import { Anchor, Box, Heading, Image, List, Paragraph, Text } from "grommet"
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
 
 const DPGLogo = () => (
   <svg
@@ -287,6 +288,10 @@ const Kosh = () => (
             </Box>
           )}
         </List>
+      </NarrowSection>
+
+      <NarrowSection>
+      <LatestProductBlogsUpdates projects={["kosh"]}/>
       </NarrowSection>
     </NarrowContentWrapper>
   </DefaultLayout>

--- a/src/pages/products/ogbv.jsx
+++ b/src/pages/products/ogbv.jsx
@@ -3,6 +3,7 @@ import NarrowSection from "../../components/atomic/layout/narrow-section"
 import DefaultLayout from "../../components/default-layout"
 import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-wrapper"
 import { Anchor, Box, Heading, Image, List, Paragraph, Text } from "grommet"
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
 
 const ogbv = () => (
   <DefaultLayout>
@@ -146,6 +147,10 @@ const ogbv = () => (
           )}
         </List>
       </NarrowSection>
+
+      <NarrowSection><LatestProductBlogsUpdates projects={["uli","ogbv"]} /></NarrowSection>
+
+
       <NarrowSection>
         <Heading level={3}>Current Team</Heading>
         <Text size="small">

--- a/src/pages/products/viral-spiral/index.jsx
+++ b/src/pages/products/viral-spiral/index.jsx
@@ -5,6 +5,7 @@ import DefaultLayout from "../../../components/default-layout"
 import NarrowContentWrapper from "../../../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../../../components/atomic/layout/narrow-section"
 import { ExternalLink, PlainLink } from "../../../components/atomic/TattleLinks"
+import { LatestProductBlogsUpdates } from "../../../components/LatestProductBlogsUpdates"
 
 const ViralSpiral = () => {
   const { product_cover, workshop_images } = useStaticQuery(graphql`
@@ -112,7 +113,8 @@ const ViralSpiral = () => {
         </NarrowSection>
       </NarrowContentWrapper>
       <NarrowContentWrapper>
-        <NarrowSection>
+      <LatestProductBlogsUpdates projects={["viral spiral"]} />
+        {/* <NarrowSection>
           <Heading level={2}>Recent Blogs</Heading>
           <Paragraph fill margin={"none"}>
             <PlainLink to="/blog/the-games-we-play-online">
@@ -146,7 +148,7 @@ const ViralSpiral = () => {
             </PlainLink>
             <Text size={"small"}>, Denny George</Text>
           </Paragraph>
-        </NarrowSection>
+        </NarrowSection> */}
       </NarrowContentWrapper>
       <NarrowContentWrapper>
         <NarrowSection>

--- a/src/pages/products/whatsapp-archiver.mdx
+++ b/src/pages/products/whatsapp-archiver.mdx
@@ -1,3 +1,5 @@
+import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
+
 # Whatsapp Archiver
 
 ## About the Archiver
@@ -45,3 +47,5 @@ Tattle is primarily interested in the content itself, and not the people or netw
 
 ## WhatsApp Scraper:
 [Go to Service/Code Repository](https://github.com/tattle-made/whatsapp-scraper/tree/master/python_scraper)
+
+<LatestProductBlogsUpdates projects={["whatsapp archiver"]}/>


### PR DESCRIPTION
This PR resolves issue #175 

## The `LatestEntries` component 

The `LatestEntries` component renders all the Blogs and Updates. This is the same component used in #174 to render blogs and updates on the homepage. In this PR I have created a separate file for it. 

## The `LatestProductBlogsUpdates` component

This component is used in every product page to render all the blogs and updates. It uses the `LatestEntries` component to render all the data. It uses the `useStaticQuery` hook to get all the blogs and updates and then, filter them out based on the projects. 

I have noticed that some of the products might need blogs and updates from multiple tags, so the `LatestProductBlogsUpdates` component takes a `projects` as a prop, an array of strings. The filtration of all the nodes coming from GraphQL would be done based on this prop. 

## Usage

I have mounted the `LatestProductBlogsUpdates` on every page inside the products directory. Many of them don't have any blogs or updates related to them. But that can be added later on. In future, we would just need to pass the names of projects on the product file to show the relevant blogs. 
