### PR TITLE
Fix: fixed the URL issue with double slashes in blogs and other places

### DIFF
--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -1,4 +1,3 @@
-// const remarkGfm = import('remark-gfm');
 import remarkGfm from "remark-gfm"
 import { dirname } from "path"
 import { fileURLToPath } from "url"

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -168,13 +168,15 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
-  if (node.internal.type === `Mdx`) {
+  if (node.internal.type === 'Mdx' || node.internal.type === 'MarkdownRemark') {
     // if (node.internal.type === `MarkdownRemark`) {
     const value = createFilePath({ node, getNode })
+    // Slugs are starting with "/"
+    const slug = value.startsWith('/') ? value.slice(1) : value;
     createNodeField({
       name: `slug`,
       node,
-      value,
+      value:slug,
     })
   }
 }


### PR DESCRIPTION
## Summary
This PR resolves issue #189, which was caused by incorrect URL generation, resulting in double slashes (`//`) in the links.

## Root Cause
The `createFilePath` function in the `gatsby-node` file generated slugs that started with a `/`, leading to URLs like `/blog//slug` when combined with the `/blog/` prefix.

## Fix
The slugs have been corrected to ensure they are concatenated without resulting in double slashes.

## Notes
During development and local builds, the Gatsby server handled `//` URLs without issues, which led to the problem being overlooked initially.
