### PR TITLE
Fix: fix layout of latest blogs and updates

### DIFF
--- a/src/blog/exploring-contentious-ideas-with-art.mdx
+++ b/src/blog/exploring-contentious-ideas-with-art.mdx
@@ -1,7 +1,7 @@
 ---
 name: Exploring contentious ideas with art
 excerpt: "Key ideas underpinning Viral Spiral"
-author: Denny Georgr
+author: Denny George
 project: Viral Spiral
 date: 2022-08-02
 tags: bts

--- a/src/components/LatestBlogsUpdates.jsx
+++ b/src/components/LatestBlogsUpdates.jsx
@@ -61,7 +61,7 @@ export default function LatestBlogsUpdates() {
 
   return (
     <>
-      <Box margin={{ top: "1em" }}>
+      <Box margin={{ vertical: "1em" }}>
         <NarrowContentWrapper width={"full"}>
           <Box>
             <Heading level={3}>Latest Blogs</Heading>

--- a/src/components/LatestEntries.jsx
+++ b/src/components/LatestEntries.jsx
@@ -5,85 +5,100 @@ import { ExternalLink } from "react-feather"
 
 function formatDateLatestEntries(date) {
   let dateString = new Date(date).toDateString("ind")
-  return dateString
-    .split(" ")
-    .slice(1)
-    .join(" ")
+  return dateString.split(" ").slice(1).join(" ")
+}
+
+/**
+ * @param {string} author
+ */
+function formatAuthor(author) {
+  if (typeof author !== "string") return ""
+  let firstDividerIndex = -1
+  let dividers = ["&", "and", "And", ","]
+  for (let d of dividers) {
+    let i = author.indexOf(d)
+
+    if (firstDividerIndex === -1) {
+      firstDividerIndex = Math.max(firstDividerIndex, i)
+    } else {
+      firstDividerIndex = Math.max(firstDividerIndex, i)
+    }
+  }
+  if (firstDividerIndex === -1) return author
+
+  author = author.substring(0, firstDividerIndex).trim().concat(" et al.")
+
+  return author
 }
 
 // Component to Display latest entries of Blogs and Updates
 export function LatestEntries({ entries, isUpdate }) {
   const size = useContext(ResponsiveContext)
 
-  return entries.map(entry => {
-    return (
-      <Box
-        width={"full"}
-        flex
-        direction="row-responsive"
-        justify="between"
-        margin={{ bottom: "1em" }}
-      >
-        <Box width={size === "small" ? "" : size === "medium" ? "30%" : "15%"}>
-          <Text size={size === "small" ? "xsmall" : "small"}>
-            {formatDateLatestEntries(entry.frontmatter.date)}
-          </Text>
-        </Box>
-
-        <Box
-          width={"full"}
-          alignContent="start"
-          justify="start"
-          pad={{ horizontal: size !== "small" ? "1em" : 0 }}
-        >
-          {isUpdate ? (
-            <Text size="small" weight={600} truncate>
-              {entry.frontmatter.title}
-            </Text>
-          ) : (
-            <Text size="small" weight={600} truncate>
-              <PlainLink to={`/blog/${entry.fields.slug}`}>
-                {entry.frontmatter.name}
-              </PlainLink>
-            </Text>
-          )}
-        </Box>
-
-        {isUpdate ? (
+  return (
+    <Box margin={{ top: "1em" }}>
+      {entries.map((entry) => {
+        return (
           <Box
-            width={size === "small" ? "" : size === "medium" ? "25%" : "15%"}
-            align={size === "small" ? "start" : "end"}
+            width={"full"}
+            flex
+            direction="row-responsive"
+            align="center"
+            margin={{ bottom: "1em" }}
           >
-            {entry.frontmatter.url && entry.frontmatter.url.length !== 0 ? (
-              <PlainLink href={entry.frontmatter.url} target={"_blank"}>
-                <Box
-                  style={{ position: "relative" }}
-                  gap={"xsmall"}
-                  direction={"row"}
-                  align={"center"}
-                  flex
+            <Box 
+            style={{ minWidth: "7em" }}
+            >
+              <Text size={size === "small" ? "xsmall" : "small"}>
+                {formatDateLatestEntries(entry.frontmatter.date)}
+              </Text>
+            </Box>
+
+            <Box
+              style={{ textAlign: "start"}} 
+              pad={{ horizontal: size !== "small" ? "1em" : 0 }}
+            >
+              {isUpdate ? (
+                <PlainLink
+                  href={entry.frontmatter.url}
+                  target={"_blank"}
+                  className="flex items-center space-x-1"
                 >
-                  <Text size={"small"}> Read More</Text>
+                  <Text size="small" weight={600} truncate>
+                    {entry.frontmatter.title}
+                  </Text>
                   <ExternalLink
-                    size={10}
-                    style={{ position: "absolute", top: 0, right: -5 }}
+                    size={14}
                   />
-                </Box>
-              </PlainLink>
-            ) : null}
+                </PlainLink>
+              ) : (
+                <Text size="small" weight={600} truncate>
+                  <PlainLink to={`/blog/${entry.fields.slug}`}>
+                    {entry.frontmatter.name}
+                  </PlainLink>
+                </Text>
+              )}
+            </Box>
+
+            {!isUpdate && (
+              <Box
+                // width={"fit"}
+                style={{
+                  textAlign: "end",
+                  minWidth: "7em",
+                  flexGrow: 1,
+                  flexShrink:0
+                }}
+                align={size === "small" ? "start" : "end"}
+              >
+                <Text size="small">
+                  {formatAuthor(entry.frontmatter?.author)}
+                </Text>
+              </Box>
+            )}
           </Box>
-        ) : (
-          <Box
-            style={{
-              minWidth:
-                size === "small" ? "" : size === "medium" ? "20%" : "15%",
-            }}
-            align={size === "small" ? "start" : "end"}
-          >
-            <Text size="small">{entry.frontmatter?.author}</Text>
-          </Box>
-        )}
-      </Box>
-    )
-  })
+        )
+      })}
+    </Box>
+  )
 }

--- a/src/components/LatestEntries.jsx
+++ b/src/components/LatestEntries.jsx
@@ -46,31 +46,33 @@ export function LatestEntries({ entries, isUpdate }) {
             align="center"
             margin={{ bottom: "1em" }}
           >
-            <Box 
-            style={{ minWidth: "7em" }}
-            >
+            <Box style={{ minWidth: "7em" }}>
               <Text size={size === "small" ? "xsmall" : "small"}>
                 {formatDateLatestEntries(entry.frontmatter.date)}
               </Text>
             </Box>
 
             <Box
-              style={{ textAlign: "start"}} 
+              style={{ textAlign: "start" }}
               pad={{ horizontal: size !== "small" ? "1em" : 0 }}
             >
               {isUpdate ? (
-                <PlainLink
-                  href={entry.frontmatter.url}
-                  target={"_blank"}
-                  className="flex items-center space-x-1"
-                >
+                entry.frontmatter.url && entry.frontmatter.url.length !== 0 ? (
+                  <PlainLink
+                    href={entry.frontmatter.url}
+                    target={"_blank"}
+                    className="flex items-center space-x-1"
+                  >
+                    <Text size="small" weight={600} truncate>
+                      {entry.frontmatter.title}
+                    </Text>
+                    <ExternalLink size={14} />
+                  </PlainLink>
+                ) : (
                   <Text size="small" weight={600} truncate>
                     {entry.frontmatter.title}
                   </Text>
-                  <ExternalLink
-                    size={14}
-                  />
-                </PlainLink>
+                )
               ) : (
                 <Text size="small" weight={600} truncate>
                   <PlainLink to={`/blog/${entry.fields.slug}`}>
@@ -87,7 +89,7 @@ export function LatestEntries({ entries, isUpdate }) {
                   textAlign: "end",
                   minWidth: "7em",
                   flexGrow: 1,
-                  flexShrink:0
+                  flexShrink: 0,
                 }}
                 align={size === "small" ? "start" : "end"}
               >

--- a/src/components/LatestProductBlogsUpdates.jsx
+++ b/src/components/LatestProductBlogsUpdates.jsx
@@ -1,9 +1,7 @@
 import { graphql, useStaticQuery } from "gatsby"
 import React from "react"
 import { projectSlugMaker } from "../lib/project-slug-maker"
-import { generateDisplayName } from "../lib/generate-display-name"
 import { Box, Heading } from "grommet"
-import NarrowContentWrapper from "./atomic/layout/narrow-content-wrapper"
 import { LatestEntries } from "./LatestEntries"
 
 export function LatestProductBlogsUpdates({ projects }) {
@@ -76,7 +74,7 @@ export function LatestProductBlogsUpdates({ projects }) {
   return (
     <>
       {latestProjectBlogs && latestProjectBlogs.length !== 0 && (
-        <Box>
+        <Box margin={{bottom:"1em"}}>
           <Box>
             <Heading level={3}>
               Latest Blogs

--- a/src/pages/products/viral-spiral/index.jsx
+++ b/src/pages/products/viral-spiral/index.jsx
@@ -112,41 +112,6 @@ const ViralSpiral = () => {
       </NarrowContentWrapper>
       <NarrowContentWrapper>
       <LatestProductBlogsUpdates projects={["viral spiral"]} />
-        {/* <NarrowSection>
-          <Heading level={2}>Recent Blogs</Heading>
-          <Paragraph fill margin={"none"}>
-            <PlainLink to="/blog/the-games-we-play-online">
-              <Text weight={800} size={"small"}>
-                The Games We Play Online
-              </Text>
-            </PlainLink>
-            <Text size={"small"}>, Adhiraj Singh</Text>
-          </Paragraph>
-          <Paragraph fill margin={"none"}>
-            <PlainLink to="/blog/viral-spiral-reading-list">
-              <Text weight={800} size={"small"}>
-                Viral Spiral Reading List
-              </Text>
-            </PlainLink>
-            <Text size={"small"}>, Denny George and Tarunima Prabhakar</Text>
-          </Paragraph>
-          <Paragraph fill margin={"none"}>
-            <PlainLink to="/blog/how-to-set-a-playtest">
-              <Text weight={800} size={"small"}>
-                How to setup a play-test session
-              </Text>
-            </PlainLink>
-            <Text size={"small"}>, Krys Martis</Text>
-          </Paragraph>
-          <Paragraph fill margin={"none"}>
-            <PlainLink to="/blog/understanding-viral-spiral-project-page">
-              <Text weight={800} size={"small"}>
-                Understanding our Project Tracker
-              </Text>
-            </PlainLink>
-            <Text size={"small"}>, Denny George</Text>
-          </Paragraph>
-        </NarrowSection> */}
       </NarrowContentWrapper>
       <NarrowContentWrapper>
         <NarrowSection>


### PR DESCRIPTION
This PR resolves issue #185 

- All the layout issues have been fixed for the latest blogs and updates.
- Removed the "Read More" column from updates. Instead, I added the hyperlink to the update title (if the link exists).
- If there is more than one author for the blog, the name will be displayed as "Author 1 et al." 