### PR TITLE
Fix: resolve blog flickering issue and other minor improvements

### DIFF
--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -13,6 +13,9 @@ const config = {
     author: `@tattlemade`,
     base_url: "https://tattle.co.in",
   },
+  flags: {
+    DEV_SSR: true //helps to detect SSR bugs and fix them without needing to do full builds with gatsby build
+  },
   plugins: [
     `gatsby-plugin-image`,
     `gatsby-plugin-postcss`,

--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -17,7 +17,6 @@ const config = {
     `gatsby-plugin-image`,
     `gatsby-plugin-postcss`,
     `gatsby-plugin-react-helmet`,
-    // `gatsby-remark-images`,
     {
       resolve: `gatsby-plugin-alias-imports`,
       options: {
@@ -82,7 +81,8 @@ const config = {
       resolve: `gatsby-plugin-sharp`,
       options: {
         defaults: {
-          quality: 100,
+          placeholder: `blurred`
+          
         },
       },
     },

--- a/src/components/LatestEntries.jsx
+++ b/src/components/LatestEntries.jsx
@@ -37,9 +37,10 @@ export function LatestEntries({ entries, isUpdate }) {
 
   return (
     <Box margin={{ top: "1em" }}>
-      {entries.map((entry) => {
+      {entries.map((entry,key) => {
         return (
           <Box
+            key={key}
             width={"full"}
             flex
             direction="row-responsive"
@@ -54,7 +55,7 @@ export function LatestEntries({ entries, isUpdate }) {
 
             <Box
               style={{ textAlign: "start" }}
-              pad={{ horizontal: size !== "small" ? "1em" : 0 }}
+              pad={{ horizontal: size !== "small" ? "1em" : "0" }}
             >
               {isUpdate ? (
                 entry.frontmatter.url && entry.frontmatter.url.length !== 0 ? (
@@ -66,7 +67,7 @@ export function LatestEntries({ entries, isUpdate }) {
                     <Text size="small" weight={600} truncate>
                       {entry.frontmatter.title}
                     </Text>
-                    <ExternalLink size={14} />
+                    <span><ExternalLink size={14} /></span>
                   </PlainLink>
                 ) : (
                   <Text size="small" weight={600} truncate>

--- a/src/components/TagsRenderer.jsx
+++ b/src/components/TagsRenderer.jsx
@@ -55,7 +55,7 @@ export default function TagsRenderer({
                 </Link>
               </Box>
             ))}
-        {sortedUniqueTags.length >= 10 && (
+        {sortedUniqueTags.length > 10 && (
           <Button onClick={toggleTagsDisplay} >
             <Box
               pad="small"

--- a/src/components/atomic/MasonryLayout.jsx
+++ b/src/components/atomic/MasonryLayout.jsx
@@ -3,27 +3,28 @@ import PropTypes from "prop-types"
 
 // Reference : https://medium.com/the-andela-way/how-to-create-a-masonry-layout-component-using-react-f30ec9ca5e99
 
-const MasonryLayout = props => {
+function MasonryLayout({columns=2,children, gap=20}){
   const columnWrapper = {}
   const result = []
 
   // create columns
-  for (let i = 0; i < props.columns; i++) {
+  for (let i = 0; i < columns; i++) {
     columnWrapper[`column${i}`] = []
   }
 
-  for (let i = 0; i < props.children.length; i++) {
-    const columnIndex = i % props.columns
+  for (let i = 0; i < children.length; i++) {
+    const columnIndex = i % columns
     columnWrapper[`column${columnIndex}`].push(
-      <div style={{ marginBottom: `${props.gap}px` }}>{props.children[i]}</div>
+      <div key={i} style={{ marginBottom: `${gap}px` }}>{children[i]}</div>
     )
   }
 
-  for (let i = 0; i < props.columns; i++) {
+  for (let i = 0; i < columns; i++) {
     result.push(
       <div
+        key={i}
         style={{
-          marginLeft: `${i > 0 ? props.gap : 0}px`,
+          marginLeft: `${i > 0 ? gap : 0}px`,
           flex: 1,
         }}
       >
@@ -39,10 +40,6 @@ MasonryLayout.propTypes = {
   columns: PropTypes.number.isRequired,
   gap: PropTypes.number.isRequired,
   children: PropTypes.arrayOf(PropTypes.element),
-}
-MasonryLayout.defaultProps = {
-  columns: 2,
-  gap: 20,
 }
 
 export default MasonryLayout

--- a/src/components/atomic/MasonryLayoutResponsive.jsx
+++ b/src/components/atomic/MasonryLayoutResponsive.jsx
@@ -2,26 +2,41 @@ import { ResponsiveContext } from "grommet"
 import React, { useContext, useEffect, useState } from "react"
 import MasonryLayout from "./MasonryLayout"
 
-const MasonryLayoutResponsive = ({ children }) => {
-  const size = useContext(ResponsiveContext)
-  const [columnCount, setColumnCount] = useState(1)
+const getColumnCount = (width) => {
+  if (width < 768) {
+    // Small (Phones)
+    return 1
+  } else if (width < 1024) {
+    // Breakpoint for tablets
+    return 2
+  } else if (width < 1536) {
+    // Medium (Desktops and larger tablets)
+    return 3
+  } else {
+    // Large (Large desktops)
+    return 5
+  }
+}
 
+const MasonryLayoutResponsive = ({ children }) => {
+  const [columnCount, setColumnCount] = useState(() =>
+    getColumnCount(window.innerWidth)
+  )
+
+  // Event to handle the number of columns based on screen, this is much faster than grommet's ResponsiveContext (Blogs were flickering intitially due to it).
   useEffect(() => {
-    switch (size) {
-      case "xsmall":
-      case "small":
-        setColumnCount(1)
-        break
-      case "medium":
-        setColumnCount(3)
-        break
-      case "large":
-        setColumnCount(5)
-        break
-      default:
-        setColumnCount(1)
+    const handleResize = () => {
+      setColumnCount(getColumnCount(window.innerWidth))
     }
-  }, [size])
+
+    window.addEventListener("resize", handleResize)
+
+    handleResize()
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
 
   return (
     <MasonryLayout columns={columnCount} gap={12}>

--- a/src/components/atomic/MasonryLayoutResponsive.jsx
+++ b/src/components/atomic/MasonryLayoutResponsive.jsx
@@ -1,6 +1,6 @@
-import { ResponsiveContext } from "grommet"
-import React, { useContext, useEffect, useState } from "react"
+import React, { useEffect, useState } from "react"
 import MasonryLayout from "./MasonryLayout"
+import { Heading } from "grommet"
 
 const getColumnCount = (width) => {
   if (width < 768) {
@@ -19,11 +19,8 @@ const getColumnCount = (width) => {
 }
 
 const MasonryLayoutResponsive = ({ children }) => {
-  const [columnCount, setColumnCount] = useState(() =>
-    getColumnCount(window.innerWidth)
-  )
+  const [columnCount, setColumnCount] = useState(null)
 
-  // Event to handle the number of columns based on screen, this is much faster than grommet's ResponsiveContext (Blogs were flickering intitially due to it).
   useEffect(() => {
     const handleResize = () => {
       setColumnCount(getColumnCount(window.innerWidth))
@@ -37,6 +34,14 @@ const MasonryLayoutResponsive = ({ children }) => {
       window.removeEventListener("resize", handleResize)
     }
   }, [])
+
+  if (columnCount === null) {
+    return (
+      <Heading level={5} alignSelf="center">
+        Loading...
+      </Heading>
+    )
+  }
 
   return (
     <MasonryLayout columns={columnCount} gap={12}>

--- a/src/components/atomic/ResponsiveImage.js
+++ b/src/components/atomic/ResponsiveImage.js
@@ -1,7 +1,6 @@
 import React from "react"
-import { Box, Text, ResponsiveContext, Image } from "grommet"
-import { GatsbyImage,getImage} from "gatsby-plugin-image"
-import { graphql, useStaticQuery } from "gatsby"
+import { Box, ResponsiveContext } from "grommet"
+import { StaticImage } from "gatsby-plugin-image"
 import styled from "styled-components"
 
 const WeirdBox = styled(Box)`
@@ -15,40 +14,25 @@ const WeirdBox = styled(Box)`
  * @function ResponsiveImage
  **/
 
-export const ResponsiveImage = ({ data, imageName }) => {
+export const ResponsiveImage = () => {
   const size = React.useContext(ResponsiveContext)
-  const { wide_image, narrow_image } = useStaticQuery(
-    graphql`
-      query {
-        wide_image: file(relativePath: { eq: "landing-page-wide.png" }) {
-          childImageSharp {
-            gatsbyImageData(
-              layout: FULL_WIDTH
-              placeholder: BLURRED
-            )
-          }
-        }
-        narrow_image: file(relativePath: { eq: "landing-page-narrow.png" }) {
-          childImageSharp {
-            gatsbyImageData(
-              layout: FULL_WIDTH
-              placeholder: BLURRED
-            )
-          }
-        }
-      }
-    `
-  );
 
   return (
     <>
       {size === "small" ? (
         <Box width={"100%"} alignSelf={"start"} height={"small"}>
-          <GatsbyImage objectFit="contain" image={getImage(narrow_image)}/>
+          <StaticImage
+            objectFit="contain"
+            src="../../images/landing-page-narrow.png"
+          />
         </Box>
       ) : (
         <Box width={"40%"} style={{ boxShadow: "none" }}>
-          <GatsbyImage objectFit="contain" imgStyle={{fill:true,alignSelf:"start"}} image={getImage(wide_image)} />
+          <StaticImage
+            objectFit="contain"
+            imgStyle={{ fill: true, alignSelf: "start" }}
+            src="../../images/landing-page-wide.png"
+          />
         </Box>
       )}
     </>

--- a/src/components/atomic/ResponsiveImage.js
+++ b/src/components/atomic/ResponsiveImage.js
@@ -22,6 +22,7 @@ export const ResponsiveImage = () => {
       {size === "small" ? (
         <Box width={"100%"} alignSelf={"start"} height={"small"}>
           <StaticImage
+            alt="landing page image"
             objectFit="contain"
             src="../../images/landing-page-narrow.png"
           />
@@ -29,6 +30,7 @@ export const ResponsiveImage = () => {
       ) : (
         <Box width={"40%"} style={{ boxShadow: "none" }}>
           <StaticImage
+            alt="landing page image"
             objectFit="contain"
             imgStyle={{ fill: true, alignSelf: "start" }}
             src="../../images/landing-page-wide.png"

--- a/src/components/atomic/layout/all-blogs-index-layout.js
+++ b/src/components/atomic/layout/all-blogs-index-layout.js
@@ -1,69 +1,64 @@
 import React, { useState } from "react"
 
-import { Box, Heading, Paragraph, Text, Image} from "grommet"
+import { Box, Heading, Paragraph, Text, Image } from "grommet"
 
 import MasonryLayoutResponsive from "../MasonryLayoutResponsive"
 import { PlainSectionLink } from "../TattleLinks"
 import { byline } from "../../default-blog-index-layout"
 import { GatsbyImage, getImage, getSrc } from "gatsby-plugin-image"
 
-
-
-export function AllBlogsIndexLayout({blogs}){
-
-    return(
-
-        <MasonryLayoutResponsive >
-          {blogs.map((blog,key )=> {
-            return (
-              <Box
-                key={key}
-                border={{ color: "visuals-3" }}
-                round={"xsmall"}
-                overflow={"hidden"}
-              >
-                <PlainSectionLink to={`/blog/${blog.fields.slug}`}>
-                  <Box>
-                    {blog.frontmatter.cover && 
-                      <Box
-                        width={"full"}
-                        // style={{ minWidth: "100%" }}
-                        height={"small"}
-                      >
-                        <GatsbyImage objectFit="cover" image={getImage(blog.frontmatter.cover)} />
-                      </Box>
-                    }
-                    <Box pad="small">
-                      <Text size={"xsmall"} weight={600}>
-                        {`${new Date(blog.frontmatter.date).toDateString()}`}
-                      </Text>
-                      <Text size={"small"}>
-                        {byline(blog.frontmatter.author)}
-                      </Text>
-                    </Box>
-                  </Box>
+export function AllBlogsIndexLayout({ blogs }) {
+  return (
+    <MasonryLayoutResponsive>
+      {blogs.map((blog, key) => {
+        return (
+          <Box
+            key={key}
+            border={{ color: "visuals-3" }}
+            round={"xsmall"}
+            overflow={"hidden"}
+          >
+            <PlainSectionLink to={`/blog/${blog.fields.slug}`}>
+              <Box>
+                {blog.frontmatter.cover && (
                   <Box
-                    pad={{ left: "small", right: "small", bottom: "medium" }}
+                    width={"full"}
+                    height={"small"}
                   >
-                    <Box direction={"row"} align={"center"}>
-                      <Heading
-                        margin={{ top: "none" }}
-                        level={3}
-                        weight={500}
-                        color={"brand"}
-                      >
-                        {blog.frontmatter.name}
-                      </Heading>
-                    </Box>
-
-                    <Paragraph size={"large"} fill margin={"none"}>
-                      {blog.frontmatter.excerpt}
-                    </Paragraph>
+                    <GatsbyImage
+                      alt="blog cover"
+                      objectFit="cover"
+                      image={getImage(blog.frontmatter.cover)}
+                    />
                   </Box>
-                </PlainSectionLink>
+                )}
+                <Box pad="small">
+                  <Text size={"xsmall"} weight={600}>
+                    {`${new Date(blog.frontmatter.date).toDateString()}`}
+                  </Text>
+                  <Text size={"small"}>{byline(blog.frontmatter.author)}</Text>
+                </Box>
               </Box>
-            )
-          })}
-        </MasonryLayoutResponsive>
-    )
+              <Box pad={{ left: "small", right: "small", bottom: "medium" }}>
+                <Box direction={"row"} align={"center"}>
+                  <Heading
+                    margin={{ top: "none" }}
+                    level={3}
+                    weight={500}
+                    color={"brand"}
+                  >
+                    {blog.frontmatter.name}
+                  </Heading>
+                </Box>
+
+                <Paragraph size={"large"} fill margin={"none"}>
+                  {blog.frontmatter.excerpt}
+                </Paragraph>
+              </Box>
+            </PlainSectionLink>
+          </Box>
+        )
+      })}
+    </MasonryLayoutResponsive>
+  )
 }

--- a/src/components/atomic/seo.js
+++ b/src/components/atomic/seo.js
@@ -11,7 +11,7 @@ import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 import { useLocation } from "@reach/router"
 
-function SEO({ description, lang, meta, title, heading }) {
+function SEO({ description='', lang=`en`, meta=[], title, heading }) {
   const location = useLocation()
   const pathname = location.pathname
   // debugger
@@ -102,12 +102,6 @@ function SEO({ description, lang, meta, title, heading }) {
       />
     </Helmet>
   )
-}
-
-SEO.defaultProps = {
-  lang: `en`,
-  meta: [],
-  description: ``,
 }
 
 SEO.propTypes = {

--- a/src/pages/datasets/index.js
+++ b/src/pages/datasets/index.js
@@ -65,6 +65,7 @@ const Datasets = () => {
                 round={"xsmall"}
               >
                 <StaticImage
+                  alt="datasets cover"
                   src={`../../images/datasets_cover.png`}
                   objectFit="cover"
                 />

--- a/src/pages/datasets/index.js
+++ b/src/pages/datasets/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useContext } from "react"
 import DefaultLayout from "../../components/default-layout"
 import {
   ResponsiveContext,
@@ -10,15 +10,13 @@ import {
   Paragraph,
   Image,
 } from "grommet"
-import { graphql, useStaticQuery } from "gatsby"
 import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../../components/atomic/layout/narrow-section"
 import {
   PlainExternalLink,
   SmartPlainLink,
 } from "../../components/atomic/TattleLinks"
-import { GatsbyImage, getImage, getSrc, StaticImage } from "gatsby-plugin-image"
-
+import { StaticImage } from "gatsby-plugin-image"
 
 const ResponsiveGrid = ({ size, children }) => {
   return size !== "small" ? (
@@ -44,101 +42,79 @@ const ResponsiveGrid = ({ size, children }) => {
  **/
 
 const Datasets = () => {
-  const [fetching, setFetching] = useState(false)
-  const size = React.useContext(ResponsiveContext)
-  console.log("------", size)
-  const { cover_image } = useStaticQuery(graphql`
-    query {
-      cover_image: file(relativePath: { eq: "datasets_cover.png" }) {
-        childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-      }
-    }
-  `)
-
-  useEffect(() => {
-    setFetching(true)
-  })
+  const size = useContext(ResponsiveContext)
 
   return (
     <DefaultLayout>
-      <ResponsiveContext.Consumer>
-        {size => (
-          <NarrowContentWrapper>
-            <NarrowSection>
-              <ResponsiveGrid size={size}>
-                <Box>
-                  <Paragraph color={"#514E80"} margin={{ top: "none" }}>
-                    This page lists Tattle Data that is vetted and safe to be
-                    opened under open access. These datasets are snapshots of
-                    the bigger archive. In the 'datasets we love' section we
-                    also list non Tattle datasets that could be useful for
-                    misinformation/ social media analysis in India.{" "}
-                  </Paragraph>
-                </Box>
-                <Box>
-                  <Box
-                    overflow={"hidden"}
-                    width={size !== "small" ? "large" : "100%"}
-                    round={"xsmall"}
-                  >
-                    <GatsbyImage
-                      image={getImage(cover_image)}
-                      objectFit="cover"
-                    />
-                  </Box>
-                </Box>
-              </ResponsiveGrid>
-              <Heading level={3} color={"#514E80"}>
-                Our Datasets
-              </Heading>
-              <ResponsiveLayoutDatasets size={size}>
-                <>
-                  <DatasetPreview
-                    previewImage={
-                      "https://images.unsplash.com/photo-1462556791646-c201b8241a94?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1045&q=80"
-                    }
-                    title={
-                      "CheckMate: Prioritizing User Generated Content for Fact Checking"
-                    }
-                    description={
-                      "A novel dataset that can be used to prioritize check-worthy posts from multi-media content in Hindi. It is unique in its focus on user generated content, language and accommodation of multi-modality in social media posts."
-                    }
-                    url={"https://arxiv.org/abs/2010.13387"}
-                    publicationDate={"28-12-2020"}
-                    linktype="external"
-                  ></DatasetPreview>
-                  <DatasetPreview
-                    previewImage={
-                      "https://images.unsplash.com/photo-1548504769-900b70ed122e?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=800&q=80"
-                    }
-                    title={"Fact Checking Sites Dataset 2019"}
-                    description={
-                      "A dataset of fact check articles scraped from IFCN certified fact check organizations in India. The data contains text and images from the article along with metadata about the organization and author"
-                    }
-                    url={"https://services.tattle.co.in/khoj/explore"}
-                    publicationDate={"07-11-2020"}
-                    linktype="external"
-                  ></DatasetPreview>
-                </>
-              </ResponsiveLayoutDatasets>
-              <Heading level={3} color={"#514E80"}>
-                Datasets We love
-              </Heading>
-              <SmartPlainLink
-                linktype="internal"
-                target="/datasets/datasets-we-love"
+      <NarrowContentWrapper>
+        <NarrowSection>
+          <ResponsiveGrid size={size}>
+            <Box>
+              <Paragraph color={"#514E80"} margin={{ top: "none" }}>
+                This page lists Tattle Data that is vetted and safe to be opened
+                under open access. These datasets are snapshots of the bigger
+                archive. In the 'datasets we love' section we also list non
+                Tattle datasets that could be useful for misinformation/ social
+                media analysis in India.{" "}
+              </Paragraph>
+            </Box>
+            <Box>
+              <Box
+                overflow={"hidden"}
+                width={size !== "small" ? "large" : "100%"}
+                round={"xsmall"}
               >
-                Please check out this selected list of datasets we find useful
-              </SmartPlainLink>
-            </NarrowSection>
-          </NarrowContentWrapper>
-        )}
-      </ResponsiveContext.Consumer>
+                <StaticImage
+                  src={`../../images/datasets_cover.png`}
+                  objectFit="cover"
+                />
+              </Box>
+            </Box>
+          </ResponsiveGrid>
+          <Heading level={3} color={"#514E80"}>
+            Our Datasets
+          </Heading>
+          <ResponsiveLayoutDatasets size={size}>
+            <>
+              <DatasetPreview
+                previewImage={
+                  "https://images.unsplash.com/photo-1462556791646-c201b8241a94?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1045&q=80"
+                }
+                title={
+                  "CheckMate: Prioritizing User Generated Content for Fact Checking"
+                }
+                description={
+                  "A novel dataset that can be used to prioritize check-worthy posts from multi-media content in Hindi. It is unique in its focus on user generated content, language and accommodation of multi-modality in social media posts."
+                }
+                url={"https://arxiv.org/abs/2010.13387"}
+                publicationDate={"28-12-2020"}
+                linktype="external"
+              ></DatasetPreview>
+              <DatasetPreview
+                previewImage={
+                  "https://images.unsplash.com/photo-1548504769-900b70ed122e?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=800&q=80"
+                }
+                title={"Fact Checking Sites Dataset 2019"}
+                description={
+                  "A dataset of fact check articles scraped from IFCN certified fact check organizations in India. The data contains text and images from the article along with metadata about the organization and author"
+                }
+                url={"https://services.tattle.co.in/khoj/explore"}
+                publicationDate={"07-11-2020"}
+                linktype="external"
+              ></DatasetPreview>
+            </>
+          </ResponsiveLayoutDatasets>
+          <Heading level={3} color={"#514E80"}>
+            Datasets We love
+          </Heading>
+          <SmartPlainLink
+            linktype="internal"
+            target="/datasets/datasets-we-love"
+          >
+            Please check out this selected list of datasets we find useful
+          </SmartPlainLink>
+        </NarrowSection>
+      </NarrowContentWrapper>
     </DefaultLayout>
   )
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -226,7 +226,7 @@ const RecentProjectSection = ({ size }) => {
           <Box gap={"small"} width={"100%"} align={"center"}>
             <Text
               size={"small"}
-              weight={"700"}
+              weight={700}
               margin={{ bottom: "small", top: "none" }}
             >
               Current Projects
@@ -275,7 +275,7 @@ const RecentProjectSection = ({ size }) => {
             <Anchor href={"/products"}>
               <Text
                 size={"small"}
-                weight={"400"}
+                weight={400}
                 margin={{ bottom: "small", top: "none" }}
               >
                 See All Projects

--- a/src/pages/products/facts.jsx
+++ b/src/pages/products/facts.jsx
@@ -1,24 +1,13 @@
 import React from "react"
-import { Anchor, Box, Heading, Image, Paragraph, Text } from "grommet"
+import { Anchor, Box, Heading, Paragraph, Text } from "grommet"
 import DefaultLayout from "../../components/default-layout"
 import NarrowContentWrapper from "../../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../../components/atomic/layout/narrow-section"
 import { PlainLink } from "../../components/atomic/TattleLinks"
-import { graphql, useStaticQuery } from "gatsby"
 import { LatestProductBlogsUpdates } from "../../components/LatestProductBlogsUpdates"
-import { GatsbyImage, getImage, getSrc, StaticImage } from "gatsby-plugin-image"
+import { StaticImage } from "gatsby-plugin-image"
 
 const Page = () => {
-  const { cover_image } = useStaticQuery(graphql`
-    query {
-      cover_image: file(relativePath: { eq: "banner_facts.jpg" }) {
-        childImageSharp {
-          gatsbyImageData(layout: FULL_WIDTH, placeholder: BLURRED)
-        }
-      }
-    }
-  `)
-
   return (
     <DefaultLayout>
       <NarrowContentWrapper>
@@ -32,9 +21,8 @@ const Page = () => {
               background={"red"}
               height={"20em"}
             >
-              <GatsbyImage
-                image={getImage(cover_image)}
-                // objectFit="cover"
+              <StaticImage
+                src={`../../images/banner_facts.jpg`}
                 alt="Cover image for facts! interactive resources for media literacy"
               />
             </Box>
@@ -75,7 +63,7 @@ const Page = () => {
             <Paragraph>supported by </Paragraph>
             <Anchor href={"https://factshala.com/"} target={"_blank"}>
               <Box width="8em" height={"4em"}>
-                <StaticImage src="../../images/factshala-logo.png" alt="logo"/>
+                <StaticImage src="../../images/factshala-logo.png" alt="logo" />
               </Box>
             </Anchor>
           </Box>

--- a/src/pages/products/feluda.jsx
+++ b/src/pages/products/feluda.jsx
@@ -149,13 +149,13 @@ const Page = () => (
               href="https://app.digitalpublicgoods.net/a/10707"
               target={"_blank"}
             >
-              <StaticImage src="../../images/dpgicon.svg"/>
+              <StaticImage alt="img" src="../../images/dpgicon.svg"/>
             </a>
           </Box>
         </Box>
         <Box direction={"row-responsive"} wrap={true}>
           <Box width={"medium"}>
-            <StaticImage src={"../../images/kosh-header-2.jpg"} />
+            <StaticImage alt="img" src={"../../images/kosh-header-2.jpg"} />
           </Box>
           <Box width={"2em"}></Box>
           <Paragraph>
@@ -211,7 +211,7 @@ const Page = () => (
             wrap={true}
           >
             <Box width={"medium"} height={"small"}>
-              <StaticImage src={"../../images/covid-tsne.png"} objectFit="contain" />
+              <StaticImage alt="img" src={"../../images/covid-tsne.png"} objectFit="contain" />
             </Box>
 
             <Box gap={"small"}>
@@ -239,7 +239,7 @@ const Page = () => (
           border={{ color: "visuals-2" }}
           overflow={"hidden"}
         >
-          <StaticImage src={"../../images/kosh-preview.png"} />
+          <StaticImage alt="img" src={"../../images/kosh-preview.png"} />
         </Box>
         <Text size={"xsmall"} margin={{ top: "xxsmall" }}>
           Preview of Kosh's UI for adding and viewing{" "}

--- a/src/pages/products/kosh.jsx
+++ b/src/pages/products/kosh.jsx
@@ -143,7 +143,7 @@ const Kosh = () => (
         <Heading level={2}>Kosh</Heading>
         <Box direction={"row-responsive"} wrap={true}>
           <Box width={"medium"}>
-            <StaticImage src={"../../images/kosh-header-2.jpg"} />
+            <StaticImage alt="img" src={"../../images/kosh-header-2.jpg"} />
           </Box>
           <Box width={"2em"}></Box>
           <Box>
@@ -162,7 +162,7 @@ const Kosh = () => (
                   href="https://app.digitalpublicgoods.net/a/10707"
                   target={"_blank"}
                 >
-                  <StaticImage src="../../images/dpgicon.svg"/>
+                  <StaticImage alt="img" src="../../images/dpgicon.svg"/>
                 </a>
               </Box>
             </Box>
@@ -214,7 +214,7 @@ const Kosh = () => (
             wrap={true}
           >
             <Box width={"medium"} height={"small"}>
-              <StaticImage src={"../../images/covid-tsne.png"} objectFit="contain" />
+              <StaticImage alt="img" src={"../../images/covid-tsne.png"} objectFit="contain" />
             </Box>
 
             <Box gap={"small"}>
@@ -242,7 +242,7 @@ const Kosh = () => (
           border={{ color: "visuals-2" }}
           overflow={"hidden"}
         >
-          <StaticImage src={"../../images/kosh-preview.png"} />
+          <StaticImage alt="img" src={"../../images/kosh-preview.png"} />
         </Box>
         <Text size={"xsmall"} margin={{ top: "xxsmall" }}>
           Preview of Kosh's UI for adding and viewing{" "}

--- a/src/pages/products/ogbv.jsx
+++ b/src/pages/products/ogbv.jsx
@@ -13,7 +13,7 @@ const ogbv = () => (
       <NarrowSection>
         <Box direction={"column"} wrap={true}>
           <Box width={"xsmall"} pad={{ right: "small" }}>
-            <StaticImage src={"../../images/products/Uli Logo-Header-03.png"} />
+            <StaticImage alt="logo" src={"../../images/products/Uli Logo-Header-03.png"} />
           </Box>
           <Box margin={{ top: "small" }}>
             <Text size="small">
@@ -109,7 +109,7 @@ const ogbv = () => (
             wrap={true}
           >
             <Box width={"medium"} height={"small"}>
-              <StaticImage src={"../../images/products/WOAH-Award.jpg"} objectFit="contain" />
+              <StaticImage alt="woah award" src={"../../images/products/WOAH-Award.jpg"} objectFit="contain" />
             </Box>
 
             <Box gap={"small"}>

--- a/src/pages/products/viral-spiral/index.jsx
+++ b/src/pages/products/viral-spiral/index.jsx
@@ -16,6 +16,7 @@ const ViralSpiral = () => {
       >
         <Box>
           <StaticImage
+            alt="cover"
             src={`../../../images/product-viral-spiral-cover.png`}
             objectFit="contain"
           />
@@ -51,6 +52,7 @@ const ViralSpiral = () => {
       <Box height={{ max: "80vh", min: "fit-content" }}>
         <Box>
           <StaticImage
+            alt="workshop image"
             src={`../../../images/product-viral-spiral-workshops.png`}
             objectFit="contain"
           />

--- a/src/pages/products/viral-spiral/index.jsx
+++ b/src/pages/products/viral-spiral/index.jsx
@@ -1,40 +1,13 @@
 import React from "react"
-import { useStaticQuery, graphql, Link } from "gatsby"
-import { Box, Heading, Text, Image, Paragraph, Anchor } from "grommet"
+import { Box, Heading, Text, Paragraph, Anchor } from "grommet"
 import DefaultLayout from "../../../components/default-layout"
 import NarrowContentWrapper from "../../../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../../../components/atomic/layout/narrow-section"
-import { ExternalLink, PlainLink } from "../../../components/atomic/TattleLinks"
+import { ExternalLink } from "../../../components/atomic/TattleLinks"
 import { LatestProductBlogsUpdates } from "../../../components/LatestProductBlogsUpdates"
-import { GatsbyImage, getImage, getSrc } from "gatsby-plugin-image"
+import { StaticImage } from "gatsby-plugin-image"
 
 const ViralSpiral = () => {
-  const { product_cover, workshop_images } = useStaticQuery(graphql`
-    query {
-      product_cover: file(
-        relativePath: { eq: "product-viral-spiral-cover.png" }
-      ) {
-        childImageSharp {
-          gatsbyImageData(
-            layout: FULL_WIDTH
-            placeholder: BLURRED
-          )
-        }
-      }
-      workshop_images: file(
-        relativePath: { eq: "product-viral-spiral-workshops.png" }
-      ) {
-        childImageSharp {
-          gatsbyImageData(
-            layout: FULL_WIDTH
-            placeholder: BLURRED
-          )
-        }
-      }
-    }
-  `)
-  
-
   return (
     <DefaultLayout>
       <Box
@@ -42,8 +15,8 @@ const ViralSpiral = () => {
         margin={{ top: "medium" }}
       >
         <Box>
-          <GatsbyImage
-            image={getImage(product_cover)}
+          <StaticImage
+            src={`../../../images/product-viral-spiral-cover.png`}
             objectFit="contain"
           />
         </Box>
@@ -75,12 +48,10 @@ const ViralSpiral = () => {
           <Heading>Play with Us</Heading>
         </NarrowSection>
       </NarrowContentWrapper>
-      <Box
-        height={{ max: "80vh", min: "fit-content" }}
-      >
+      <Box height={{ max: "80vh", min: "fit-content" }}>
         <Box>
-          <GatsbyImage
-            image={getImage(workshop_images)}
+          <StaticImage
+            src={`../../../images/product-viral-spiral-workshops.png`}
             objectFit="contain"
           />
         </Box>
@@ -108,7 +79,7 @@ const ViralSpiral = () => {
         </NarrowSection>
       </NarrowContentWrapper>
       <NarrowContentWrapper>
-      <LatestProductBlogsUpdates projects={["viral spiral"]} />
+        <LatestProductBlogsUpdates projects={["viral spiral"]} />
       </NarrowContentWrapper>
       <NarrowContentWrapper>
         <NarrowSection>

--- a/src/pages/theme.js
+++ b/src/pages/theme.js
@@ -313,7 +313,8 @@ const CoverSection = () => {
         </Paragraph>
       </Box>
       <Box fill={"horizontal"} height={"medium"}>
-        <StaticImage
+        <Image
+          alt=""
           objectFit={"cover"}
           src={
             "https://images.unsplash.com/photo-1553356084-58ef4a67b2a7?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw"
@@ -347,8 +348,9 @@ const StaticCoverSection = () => {
         </Paragraph>
       </Box>
       <Box fill={"horizontal"} height={"medium"}>
-        <Image
-          fit={"cover"}
+        <StaticImage
+          objectFit={"cover"}
+          alt="gatsby static image"
           src={
             "https://images.unsplash.com/photo-1553356084-58ef4a67b2a7?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw"
           }

--- a/src/pages/v2/case-study-preview.js
+++ b/src/pages/v2/case-study-preview.js
@@ -27,7 +27,7 @@ const CaseStudyPreview = ({
     >
       {coverImage ? (
         <Box width={"100%"} height={"small"}>
-          <GatsbyImage image={coverImage} objectFit="contain" />
+          <GatsbyImage alt="cover" image={coverImage} objectFit="contain" />
         </Box>
       ) : null}
 
@@ -41,7 +41,7 @@ const CaseStudyPreview = ({
               overflow={"hidden"}
               justify="center"
             >
-              <GatsbyImage image={previewImage} objectFit="contain"/>
+              <GatsbyImage alt="preview" image={previewImage} objectFit="contain"/>
             </Box>
             <Box>
               <Heading level={3} margin={{ bottom: "4.578px", top: "7.324px" }}>

--- a/src/pages/v2/we-build-for.js
+++ b/src/pages/v2/we-build-for.js
@@ -57,6 +57,7 @@ const WeBuildFor = () => {
           style={{ cursor: "zoom-in" }}
         >
           <GatsbyImage
+            alt="img"
             objectFit="contain"
             image={getImage(stakeholder_simple)}
           />
@@ -70,6 +71,7 @@ const WeBuildFor = () => {
           <Box fill background={"brand"}>
             <Button label="close" onClick={() => setShow(false)} />
             <GatsbyImage
+              alt="img"
               objectFit="contain"
               image={getImage(stakeholder_map)}
             />

--- a/src/pages/values.js
+++ b/src/pages/values.js
@@ -3,7 +3,7 @@ import { Box, Heading, Paragraph } from "grommet"
 import NarrowContentWrapper from "../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../components/atomic/layout/narrow-section"
 import DefaultLayout from "../components/default-layout"
-import { StaticImage } from "gatsby-plugin-image"
+import { StaticImage} from "gatsby-plugin-image"
 
 const Section = ({ children }) => (
   <NarrowContentWrapper>
@@ -34,6 +34,7 @@ export default function Values() {
             margin={{ right: "small", bottom: "small", top: "medium" }}
           >
             <StaticImage
+              alt="value img"
               objectFit={"contain"}
               src={`../images/values-openness.jpg`}
             />
@@ -70,6 +71,7 @@ export default function Values() {
             margin={{ right: "small", bottom: "small", top: "medium" }}
           >
             <StaticImage
+              alt="value img"
               objectFit={"contain"}
               src={`../images/values-accessibility.jpg`}
             />
@@ -97,6 +99,7 @@ export default function Values() {
             margin={{ right: "small", bottom: "small", top: "medium" }}
           >
             <StaticImage
+              alt="value img"
               objectFit={"contain"}
               src={`../images/values-sustainability.jpg`}
             />
@@ -127,6 +130,7 @@ export default function Values() {
             margin={{ right: "small", bottom: "small", top: "medium" }}
           >
             <StaticImage
+              alt="value img"
               objectFit={"contain"}
               src={`../images/values-humility.jpg`}
             />
@@ -154,6 +158,7 @@ export default function Values() {
             margin={{ right: "small", bottom: "small", top: "medium" }}
           >
             <StaticImage
+              alt="value img"
               objectFit={"contain"}
               src={`../images/values-curiosity.jpg`}
             />

--- a/src/pages/values.js
+++ b/src/pages/values.js
@@ -1,10 +1,9 @@
 import React from "react"
-import { graphql } from "gatsby"
 import { Box, Heading, Paragraph } from "grommet"
 import NarrowContentWrapper from "../components/atomic/layout/narrow-content-wrapper"
 import NarrowSection from "../components/atomic/layout/narrow-section"
 import DefaultLayout from "../components/default-layout"
-import { GatsbyImage, getImage} from "gatsby-plugin-image"
+import { StaticImage } from "gatsby-plugin-image"
 
 const Section = ({ children }) => (
   <NarrowContentWrapper>
@@ -12,14 +11,7 @@ const Section = ({ children }) => (
   </NarrowContentWrapper>
 )
 
-export default function Values({ data }) {
-  const {
-    value_openness,
-    value_accessibility,
-    value_sustainability,
-    value_humility,
-    value_curiosity,
-  } = data
+export default function Values() {
   return (
     <DefaultLayout>
       <Section>
@@ -35,16 +27,15 @@ export default function Values({ data }) {
           Openness
         </Heading>
 
-        <Box direction={"row-responsive"} align="center">
+        <Box direction={"row-responsive"} align="start">
           <Box
             width={"small"}
-
             flex={"grow"}
-            margin={{ right: "small", bottom:"small" }}
+            margin={{ right: "small", bottom: "small", top: "medium" }}
           >
-            <GatsbyImage
+            <StaticImage
               objectFit={"contain"}
-              image={getImage(value_openness)}
+              src={`../images/values-openness.jpg`}
             />
           </Box>
           <Box>
@@ -72,15 +63,15 @@ export default function Values({ data }) {
         <Heading level={3} margin={{ bottom: "xsmall" }}>
           Accessibility
         </Heading>
-        <Box direction={"row-responsive"} align="center">
+        <Box direction={"row-responsive"} align="start">
           <Box
             width={"small"}
             flex={"grow"}
-            margin={{ right: "small", bottom: "small" }}
+            margin={{ right: "small", bottom: "small", top: "medium" }}
           >
-            <GatsbyImage
+            <StaticImage
               objectFit={"contain"}
-              image={getImage(value_accessibility)}
+              src={`../images/values-accessibility.jpg`}
             />
           </Box>
           <Box>
@@ -99,15 +90,15 @@ export default function Values({ data }) {
         <Heading level={3} margin={{ bottom: "xsmall" }}>
           Sustainability
         </Heading>
-        <Box direction={"row-responsive"} align="center">
+        <Box direction={"row-responsive"} align="start">
           <Box
             width={"small"}
             flex={"grow"}
-            margin={{ right: "small", bottom: "small" }}
+            margin={{ right: "small", bottom: "small", top: "medium" }}
           >
-            <GatsbyImage
+            <StaticImage
               objectFit={"contain"}
-              image={getImage(value_sustainability)}
+              src={`../images/values-sustainability.jpg`}
             />
           </Box>
           <Box>
@@ -129,15 +120,15 @@ export default function Values({ data }) {
         <Heading level={3} margin={{ bottom: "xsmall" }}>
           Humility
         </Heading>
-        <Box direction={"row-responsive"} align="center">
+        <Box direction={"row-responsive"} align="start">
           <Box
             width={"small"}
             flex={"grow"}
-            margin={{ right: "small", bottom: "small" }}
+            margin={{ right: "small", bottom: "small", top: "medium" }}
           >
-            <GatsbyImage
+            <StaticImage
               objectFit={"contain"}
-              image={getImage(value_humility)}
+              src={`../images/values-humility.jpg`}
             />
           </Box>
           <Box>
@@ -156,15 +147,15 @@ export default function Values({ data }) {
         <Heading level={3} margin={{ bottom: "xsmall" }}>
           Curiosity
         </Heading>
-        <Box direction={"row-responsive"} align="center">
+        <Box direction={"row-responsive"} align="start">
           <Box
             width={"small"}
             flex={"grow"}
-            margin={{ right: "small", bottom: "small" }}
+            margin={{ right: "small", bottom: "small", top: "medium" }}
           >
-            <GatsbyImage
+            <StaticImage
               objectFit={"contain"}
-              image={getImage(value_curiosity)}
+              src={`../images/values-curiosity.jpg`}
             />
           </Box>
           <Box>
@@ -198,52 +189,3 @@ export default function Values({ data }) {
     </DefaultLayout>
   )
 }
-
-export const query = graphql`
-  query ValuesImageQuery {
-    value_openness: file(relativePath: { eq: "values-openness.jpg" }) {
-      childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-    }
-    value_accessibility: file(
-      relativePath: { eq: "values-accessibility.jpg" }
-    ) {
-      childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-    }
-    value_sustainability: file(
-      relativePath: { eq: "values-sustainability.jpg" }
-    ) {
-      childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-    }
-    value_humility: file(relativePath: { eq: "values-humility.jpg" }) {
-      childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-    }
-    value_curiosity: file(relativePath: { eq: "values-curiosity.jpg" }) {
-      childImageSharp {
-        gatsbyImageData(
-          layout: FULL_WIDTH
-          placeholder: BLURRED
-        )
-      }
-    }
-  }
-`


### PR DESCRIPTION
# Fix: Resolve blog flickering issue and other minor improvements

- This PR resolves issue #195 and also is related to PR #196 

## Table of Contents
- [Replaced `GatsbyImage` components with `StaticImage` components wherever possible](#replaced-gatsbyimage-components-with-staticimage-components-wherever-possible)
- [Resolved the Flickering issue in the blog index page and new breakpoint for tablets](#resolved-the-flickering-issue-in-the-blog-index-page-and-new-breakpoint-for-tablets)
- [Fixed the `Show all tags` bug](#fixed-the-show-all-tags-bug)
- [Added the `DEV_SSR` flag to config file](#added-the-dev_ssr-flag-to-config-file)
- [Tried resolving all the warnings and errors in the browser's console](#tried-resolving-all-the-warnings-and-errors-in-the-browsers-console)
- [Minor: Fixed the `external link icon` size issue in mobile screens, which was used in the `LatestEntries` component ](#minor-fixed-the-external-link-icon-size-issue-in-mobile-screens-which-was-used-in-the-latestentries-component)

## Replaced `GatsbyImage` components with `StaticImage` components wherever possible
- Wherever possible, I have replaced the `GatsbyImage` components with `StaticImage` components throughout the project. 
- Earlier the querying of images might have been done so that Gtasby would process them (speculation), but with the latest version of `gatsby-plugin-image`, the `StaticImage` component also does all the pre-processing and we can pass the image URLs directly.
- So I removed all the queries where we were querying the images and now just using the URLs to render static images wherever possible.

## Resolved the Flickering issue in the blog index page and new breakpoint for tablets
- The issue #195 is also resolved. 
- Instead of using the grommet library's `ResponsiveContext` to find out the number of required columns, I created a custom event listener to do that.  
- I also added a new breakpoint for medium screens (like tablets), which would set the number of columns to 2. 
- To address the flickering issue, I have added a Loading text while the blogs get loaded. We can use some other component or some loader in the future instead of just "Loading..." text.
- The issue was that we were setting the initial value in useState to be 1. I tried changing it and replaced it by calculating the columns based on `window.innerWidth`. It worked fine during the development but the compilation failed during build time because, during the SSR, the window object cannot be accessed.  

## Fixed the `Show all tags` bug
- Earlier, the "show all tags" toggle button was being shown even when there were no more tags (for project tags). This bug came to my notice as a new project tag was recently added and the toggle button was showing even when there were no more tags. 

## Added the `DEV_SSR` flag to config file
- I have added a `DEV_SSR` flag in the config file to catch any server-side rendering error. This would help us to know beforehand during development if there would be any error during the build time.
- Ref: https://www.gatsbyjs.com/docs/debugging-html-builds/#ssr-during-gatsby-develop

## Tried resolving all the warnings and errors in the browser's console
- I have tried resolving all the warnings and errors in the browser's console.
- Except for one warning, which seems to be related to some internal component in Gatsby (speculation). 
- Some of the warnings were due to the use of the `defaultProps`, which is going to be deprecated in the next version. I changed it in the `SEO` component and `MasonryLayout` component. 
- There are other warnings too (the yellow ones) which we see during the development in the IDE's terminal, those warnings are mostly related to declaring a component and not using it.

## Minor: Fixed the `external link icon` size issue in mobile screens, used in the `LatestEntries` component 
- In mobile screens, earlier in the latest updates section on the homepage, the external link icons were not rendering with proper width when the title was too long. This bug is fixed.