### PR TITLE
create blog dashboard route with blogs data accessible

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -72,6 +72,11 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     component: require.resolve(`./src/components/default-blog-index-layout.js`),
     context: { projects },
   })
+  // Blog Dashboard
+  createPage({
+    path: `/blog/dashboard/`,
+    component: require.resolve(`./src/components/default-blog-dashboard.js`),
+  })
   //siteMapURLs.set("Blogs", "/blog")
   siteMapNodes.push({ name: "blog", isDir: false, node: { name: "blog" } })
 

--- a/src/components/default-blog-dashboard.js
+++ b/src/components/default-blog-dashboard.js
@@ -1,0 +1,46 @@
+import { graphql } from "gatsby"
+import DefaultLayoutNarrow from "./default-layout-narrow"
+import React from "react"
+
+export default function BlogDashboard({ data }) {
+  let blogCellsData = data.allMdx.nodes.map(blog=>{
+    return (
+      {
+        slug:blog.fields.slug,
+        name:blog.frontmatter.name,
+        date: blog.frontmatter.date
+      }
+    )
+  })
+
+  console.log(blogCellsData)
+
+  return (
+    <DefaultLayoutNarrow>
+      <div>Blogs Calendar View</div>
+    </DefaultLayoutNarrow>
+  )
+}
+
+export const query = graphql`
+  query BlogIndexQuery {
+    allMdx(
+      filter: { internal: { contentFilePath: { regex: "/.*/src/blog/" } } }
+      sort: { frontmatter: { date: DESC } }
+    ) {
+      nodes {
+        fields {
+          slug
+        }
+        frontmatter {
+          name
+          excerpt
+          author
+          project
+          date
+          tags
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
This PR is linked to issue #205 

- Created a new route `/blog/dashboard` where a calendar view of all the blogs would be visible.
- Wrote a Gatsby query to make all the relevant data accessible to the component.
- We will use this data while rendering the Calendar view of all the blog posts.