### PR TITLE
Fix Twitter Card Title for Blog Posts

### DIFF
--- a/src/components/atomic/AppShell.js
+++ b/src/components/atomic/AppShell.js
@@ -44,7 +44,7 @@ const AppShell = ({
   return (
     <Grommet theme={TattleTheme} full>
       <Box fill direction={"column"}>
-        <SEO title={`Tattle`} heading={headerLabel} meta={meta} />
+        <SEO title={meta?.name || headerLabel || `Tattle`} heading={headerLabel} meta={meta} />
         {/* {location.pathname !== MODAL_PATH && (
           <Box
             background={"accent-1"}


### PR DESCRIPTION
Fixes [#232](https://github.com/tattle-made/website/issues/232)
Description:
This PR fixes an issue where the Twitter card preview was not displaying the correct blog post title. Previously, the title in the component was hardcoded to "Tattle", causing the preview to always show the default value instead of the actual post title.

Changes Made:
Updated component's title prop to dynamically use meta?.name || headerLabel || "Tattle".

Ensured that the blog post title is correctly reflected when sharing links on Twitter and other social media platforms.

Testing & Validation:
Used Twitter Card Validator to confirm that the correct title appears in the preview.

Inspected the meta tags in the browser to ensure the correct og:title and twitter:title values.

Impact:
Blog post titles will now correctly appear in link previews on Twitter and other social media platforms.