### PR TITLE
fix: enforce tailwind classes on grommet components

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -12,5 +12,5 @@ import "./prism-cb.css"
 
 // Gatsby API to set Wrapper components. Wrapping entire root with Grommet to get access to especially ResponsiveContext
 export const wrapRootElement = ({ element }) => {
-  return <Grommet>{element}</Grommet>
+  return <Grommet><div id="app">{element}</div></Grommet>
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -12,5 +12,5 @@ import "./prism-cb.css"
 
 // Gatsby API to set Wrapper components. Wrapping entire root with Grommet to get access to especially ResponsiveContext
 export const wrapRootElement = ({ element }) => {
-  return <Grommet>{element}</Grommet>
+  return <Grommet><div id="app">{element}</div></Grommet>
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
   theme: {
     extend: {},
   },
+  important: "#app",
   plugins: [],
   corePlugins: {
     preflight: false,


### PR DESCRIPTION
This PR fixes the issue of Tailwind classes not being applied to all the Grommet components in production. 
Reference Documentation used to implement the changes: https://v3.tailwindcss.com/docs/configuration#important  