### PR TITLE
Fix: Add horizontal padding to header for better mobile responsiveness

### DIFF
--- a/src/components/atomic/SimpleHeader.js
+++ b/src/components/atomic/SimpleHeader.js
@@ -133,7 +133,7 @@ const SimpleHeader = ({ label, target, primaryNav, onHamburgerClicked }) => {
   }
 
   return (
-    <Box direction={"row"} wrap={true} height={"76.8px"} width={"960px"}>
+    <Box direction={"row"} wrap={true} height={"76.8px"} width={"960px"} pad={{ horizontal: "medium" }}>
       {size !== "small" ? (
         <Box direction={"row"} align={"center"} width={"960px"} gap={"xsmall"}>
           <TattleLogo data={{ fill: Theme.text_color_light }} />


### PR DESCRIPTION
This PR fixes #274 

### What does this PR do?
Adds horizontal padding to the header component to improve spacing and readability on smaller screen sizes (mobile view). 

### Changes made:
- Updated the SimpleHeader component
- Applied `pad={{ horizontal: "medium" }}` to the outer Box

### Screenshots:
![image](https://github.com/user-attachments/assets/cd405725-ad54-4bad-b788-29de27f197bb)


