### PR TITLE
fix(tags): ensure consistent vertical spacing across mobile view (#276)

### DIFF
--- a/src/components/TagsRenderer.jsx
+++ b/src/components/TagsRenderer.jsx
@@ -28,9 +28,10 @@ export default function TagsRenderer({
   }
 
   return (
+    <Box margin={{ bottom: "small" }}>
     <Box flex direction="row" align="baseline" gap="xsmall">
       <Box>
-        <Heading level={4} marging={{ bottom: "small" }}>
+        <Heading level={4} margin={{ bottom: "small" }}>
           {tagTypeHeading}
         </Heading>
       </Box>
@@ -38,25 +39,28 @@ export default function TagsRenderer({
       <Box flex direction="row" gap="small" align="center" wrap={true}>
         {showAllTags
           ? sortedUniqueTags.map((tag) => (
-              <Box key={tag} margin={{ bottom: "small" }}>
-                <Link
-                  to={tagBaseURL.concat(tag)}
-                  style={{ textDecoration: "none" }}
-                >
-                  <TagBubbleBlog data={{ label: tag, count: tagCounts[tag] }} />
-                </Link>
-              </Box>
-            ))
+            <Box key={tag} margin={{ bottom: "small" }}>
+              <Link
+                to={tagBaseURL.concat(tag)}
+                style={{ textDecoration: "none" }}
+              >
+                <TagBubbleBlog data={{ label: tag, count: tagCounts[tag] }} />
+              </Link>
+            </Box>
+          ))
           : sortedUniqueTags.slice(0, 10).map((tag) => (
-              <Box key={tag}>
-                <Link
-                  to={tagBaseURL.concat(tag)}
-                  style={{ textDecoration: "none" }}
-                >
-                  <TagBubbleBlog data={{ label: tag, count: tagCounts[tag] }} />
-                </Link>
-              </Box>
-            ))}
+            <Box key={tag}
+              pad={{ vertical: "xsmall" }}
+              round="xsmall"
+              margin={{  bottom: "xxsmall" }}>
+              <Link
+                to={tagBaseURL.concat(tag)}
+                style={{ textDecoration: "none" }}
+              >
+                <TagBubbleBlog data={{ label: tag, count: tagCounts[tag] }} />
+              </Link>
+            </Box>
+          ))}
         {sortedUniqueTags.length > 10 && (
           <Button onClick={toggleTagsDisplay}>
             <Box
@@ -70,6 +74,7 @@ export default function TagsRenderer({
             </Box>
           </Button>
         )}
+      </Box>
       </Box>
     </Box>
   )


### PR DESCRIPTION
This PR fixes issue #276 by applying consistent vertical spacing between tags on mobile view.

**Changes Made:**
- Wrapped tag items in a <Box> with:
  - `pad={{ vertical: "xsmall" }}`
  - `round="xsmall"`
  - `margin={{ bottom: "xxsmall" }}`
- This ensures that each tag has padding and margin even before any interaction like "Show more tags".
- Also added a `margin={{ bottom: "small" }}` to the container <Box> above the tags to maintain spacing in the layout.

This ensures the tag layout looks consistent and avoids layout shift on small screens.

**Screeenshort**
![image](https://github.com/user-attachments/assets/73f0d4c9-35d2-461c-ad46-7e13de440bbd)
