### PR TITLE
fix: improve tag spacing in research page components

### DIFF
--- a/src/components/atomic/TagBubble.js
+++ b/src/components/atomic/TagBubble.js
@@ -10,7 +10,6 @@ const TagBubble = ({ data }) => {
         background={"visuals-1"}
         pad={"xsmall"}
         width={"fit-content"}
-        margin={{ bottom: "xsmall" }}
       >
         <Text size={"xsmall"}>{data.label}</Text>{" "}
       </Box>

--- a/src/components/atomic/TagBubble.js
+++ b/src/components/atomic/TagBubble.js
@@ -10,6 +10,7 @@ const TagBubble = ({ data }) => {
         background={"visuals-1"}
         pad={"xsmall"}
         width={"fit-content"}
+        margin={{ bottom: "xsmall" }}
       >
         <Text size={"xsmall"}>{data.label}</Text>{" "}
       </Box>

--- a/src/pages/research.js
+++ b/src/pages/research.js
@@ -35,7 +35,7 @@ const FeaturedListItem = ({ item }) => {
             <Heading level={3} margin={{ bottom: "4.578px", top: "7.324px" }}>
               {item.title}
             </Heading>
-            <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }}>
+            <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }} className="gap-y-2">
               {item.tags.map((tag, index) => (
                 <TagBubble key={index} data={{ label: tag }} />
               ))}
@@ -70,13 +70,13 @@ const AllListItem = ({ item }) => (
           >
             {item.title}
           </Heading>
-          <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }}>
+          <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }} className="gap-y-2">
             {item.tags.map((tag, index) => (
               <TagBubble key={index} data={{ label: tag }} />
             ))}
           </Box>
 
-          <Paragraph size={"medium"} fill>
+          <Paragraph size={"medium"} fill>                                                        
             {item.description}
           </Paragraph>
         </Box>

--- a/src/pages/research.js
+++ b/src/pages/research.js
@@ -20,7 +20,7 @@ const FeaturedListItem = ({ item }) => {
   return (
     <Box
       direction={"column"}
-      onClick={() => {}}
+      onClick={() => { }}
       hoverIndicator={true}
       focusIndicator={false}
       width={size === "small" ? "100%" : "50%"}
@@ -35,11 +35,12 @@ const FeaturedListItem = ({ item }) => {
             <Heading level={3} margin={{ bottom: "4.578px", top: "7.324px" }}>
               {item.title}
             </Heading>
-            <Box direction={"row"} wrap={true} gap={"xsmall"}>
-              {item.tags.map(tag => (
-                <TagBubble data={{ label: tag }} />
+            <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }}>
+              {item.tags.map((tag, index) => (
+                <TagBubble key={index} data={{ label: tag }} />
               ))}
             </Box>
+
             <Paragraph size={"medium"}>{item.description}</Paragraph>
           </Box>
         </Box>
@@ -52,7 +53,7 @@ const AllListItem = ({ item }) => (
   <Box
     direction={"column"}
     pad={"xsmall"}
-    onClick={() => {}}
+    onClick={() => { }}
     hoverIndicator={true}
     focusIndicator={false}
   >
@@ -69,11 +70,12 @@ const AllListItem = ({ item }) => (
           >
             {item.title}
           </Heading>
-          <Box direction={"row"} wrap={true} gap={"xsmall"}>
-            {item.tags.map(tag => (
-              <TagBubble data={{ label: tag }} />
+          <Box direction="row" wrap gap="xsmall" margin={{ bottom: "small" }}>
+            {item.tags.map((tag, index) => (
+              <TagBubble key={index} data={{ label: tag }} />
             ))}
           </Box>
+
           <Paragraph size={"medium"} fill>
             {item.description}
           </Paragraph>


### PR DESCRIPTION
### Changes Made:
- Added `wrap`, `gap`, and vertical margin between tags in **FeaturedListItem** and **AllListItem** components.
- Included missing `key` props for list items to fix React warnings.
- Updated **TagBubble** to add `margin-bottom` for better vertical spacing across screen sizes.

### Context:
Tags on the research page were appearing too close, especially on mobile devices. These changes ensure consistent and clean spacing between tags and improve rendering by addressing missing keys.

###Screenshorts:
![image](https://github.com/user-attachments/assets/34e600c6-2383-4ab1-851c-9ad1b394e924)

in mobile view:

![image](https://github.com/user-attachments/assets/4abc53a1-4a93-4f86-81cc-2449292a85e5)
