### PR TITLE
Show 'Other Projects' in Tools (Mobile Nav) & Add Description

### DIFF
--- a/src/components/atomic/SimpleHeader.js
+++ b/src/components/atomic/SimpleHeader.js
@@ -45,7 +45,7 @@ const dropDownOptionsTools = [
     id: 4,
     target: "/products/",
     label: "Other Projects",
-    description: "Explore more initiatives",
+    description: "",
   },
 ]
 

--- a/src/components/atomic/SimpleHeader.js
+++ b/src/components/atomic/SimpleHeader.js
@@ -45,7 +45,7 @@ const dropDownOptionsTools = [
     id: 4,
     target: "/products/",
     label: "Other Projects",
-    description: "",
+    description: "Explore more initiatives",
   },
 ]
 
@@ -188,7 +188,7 @@ const SimpleHeader = ({ label, target, primaryNav, onHamburgerClicked }) => {
                   Products{" "}
                 </Heading>
                 <Box flex={"grow"} margin={{ left: "medium" }}>
-                  {[0, 1, 2, 3].map(i => (
+                  {[0, 1, 2, 3, 4].map(i => (
                     <MobileNavItemInternalLink
                       label={dropDownOptionsTools[i].label}
                       description={dropDownOptionsTools[i].description}


### PR DESCRIPTION
This PR fixes #286 

###  Changes Made:

- **Displayed 'Other Projects'** in the mobile nav by including its index in the mapped array (`[0, 1, 2, 3, 4]`).
- **Added a description** for the "Other Projects" item inside the `dropDownOptionsTools` array:
  ```js
  {
    id: 4,
    target: "/products/",
    label: "Other Projects",
    description: "Explore more initiatives"
  }
  
  ### Screenshot:
  
![image](https://github.com/user-attachments/assets/07c86b23-32da-4d88-bb95-dab4f299b816)

  