### PR TITLE
docs: add JSDoc to BlogDashboard component

### DIFF
--- a/src/components/default-blog-dashboard.js
+++ b/src/components/default-blog-dashboard.js
@@ -3,6 +3,17 @@ import DefaultLayout from "./default-layout"  // Changed to DefaultLayout
 import React from "react"
 import Calendar from "./Calendar"
 
+
+/**
+ * BlogDashboard component renders the main blog dashboard layout.
+ * It maps blog data (slug, name, date) into a heatmap-style calendar UI.
+ *
+ * @component
+ * @param {Object} props - React props
+ * @param {Object} props.data - GraphQL data containing all blog MDX nodes
+ * @returns {JSX.Element} Blog dashboard with a calendar view inside a DefaultLayout
+ */
+
 export default function BlogDashboard({ data }) {
   let blogCellsData = data.allMdx.nodes.map(blog => {
     return {


### PR DESCRIPTION
#### This pull request adds documentation for the BlogDashboard component, which renders the main blog dashboard layout using blog post data.

- Documented props and return type
- Described how blog metadata (slug, name, date) is used
- Clarified its role in rendering the dashboard inside a DefaultLayout

