### PR TITLE
docs: add JSDoc to BlogIndex component 

### DIFF
--- a/src/components/default-blog-index-layout.js
+++ b/src/components/default-blog-index-layout.js
@@ -11,6 +11,19 @@ export const byline = (name, project) => {
   if (name) return `${name}`
 }
 
+/**
+ * BlogIndex lists all blog posts with tag filters.
+ *
+ * Renders normal and project tags using `TagsRenderer`,
+ * and displays posts via `AllBlogsIndexLayout`.
+ *
+ * @param {Object} props
+ * @param {Object} props.data - Blog data from GraphQL.
+ * @param {Object} props.pageContext - Page context from Gatsby.
+ *
+ * @returns {JSX.Element}
+ */
+
 const BlogIndex = ({ data, pageContext }) => {
   const blogs = data.allMdx.nodes
   const cover_blog_index = data.cover_blog_index


### PR DESCRIPTION
#### This pull request adds documentation for the BlogIndex component, which renders blog posts with tag and project filters.

- Added JSDoc to `BlogIndex` component
- Describes usage of `TagsRenderer` and `AllBlogsIndexLayout`