### PR TITLE
docs: Add JSDoc for DefaultLayoutNarrow layout component

### DIFF
--- a/src/components/default-layout-narrow.js
+++ b/src/components/default-layout-narrow.js
@@ -7,6 +7,15 @@ import { useLocation } from "@reach/router"
  * @function DefaultLayout
  **/
 
+/**
+ * Narrow layout wrapper that updates label from the current route.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Layout content
+ * @returns {JSX.Element}
+ */
+
+
 const DefaultLayoutNarrow = ({ children }) => {
   const location = useLocation()
   const [label, setLabel] = useState("")


### PR DESCRIPTION
This pull request adds documentation for the DefaultLayoutNarrow component, which renders children inside a narrow AppShell layout.

- Documented props and return type using JSDoc
- Described the side effect that updates label based on the current route using useEffect