### PR TITLE
docs: Add JSDoc for DefaultLayout component

### DIFF
--- a/src/components/default-layout.js
+++ b/src/components/default-layout.js
@@ -7,6 +7,17 @@ import { useLocation } from "@reach/router"
  * @function DefaultLayout
  **/
 
+
+/**
+ * Full-width layout wrapper using AppShell.
+ *
+ * Updates internal label state based on current route.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Content to render inside the layout
+ * @returns {JSX.Element}
+ */
+
 const DefaultLayout = ({ children }) => {
   const location = useLocation()
   const [label, setLabel] = useState("")


### PR DESCRIPTION
This pull request adds documentation for the DefaultLayout component, which renders children inside a full-width AppShell layout.

- Included JSDoc for props and return type
- Described the useEffect logic that extracts the first route segment into a label
- 