### PR TITLE
docs: Add JSDoc to Tag Page layout component

### DIFF
--- a/src/components/default-tag-page-layout.js
+++ b/src/components/default-tag-page-layout.js
@@ -3,10 +3,28 @@ import { graphql, Link } from "gatsby"
 import useBlogTags from "../hooks/useBlogTags"
 import TagPage from "./TagPage"
 
+/**
+ * Returns a formatted byline string based on the presence of author and project.
+ *
+ * @param {string} author - The name of the author.
+ * @param {string} project - The associated project name.
+ * @returns {string | undefined} A formatted byline (e.g., "Author - Project"), or just "Author" if project is not provided.
+ */
+
 const byline = (author, project) => {
   if (author && project) return `${author} - ${project}`
   if (author) return `${author}`
 }
+
+/**
+ * TagTemplate component renders a tag-specific page that lists all blog posts
+ * associated with a particular tag.
+ *
+ * @param {Object} props - The props object.
+ * @param {Object} props.data - GraphQL data object, expected to contain allMdx nodes.
+ * @param {Object} props.pageContext - Context passed by Gatsby, including the tag name.
+ * @returns {JSX.Element} A TagPage component displaying filtered posts.
+ */
 
 export default function TagTemplate({ data, pageContext }) {
   const { tagCounts } = useBlogTags()


### PR DESCRIPTION
#### This pull request adds documentation for the TagTemplate layout component and its associated helper function byline.

- Documented `TagTemplate` component which filters blog posts based on tag from `pageContext`
- Added JSDoc to `byline` helper function, which formats author and project information
- Improved overall code readability and maintainability
